### PR TITLE
Add Basic CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 name: "CI"
 
 on:


### PR DESCRIPTION
This PR introduces CI and adds the following job: 
- job to run linting
- job to run the doc build