### PR TITLE
Fix check for normalized against

### DIFF
--- a/nsight/visualization.py
+++ b/nsight/visualization.py
@@ -432,7 +432,10 @@ def visualize(
                     len(normalized_values) == 1
                 ), "Normalized column should have exactly one unique value"
                 normalized_against = normalized_values[0]
-                if normalized_against is not False:
+                if (
+                    normalized_against is not False
+                    and normalized_against is not np.bool(False)
+                ):
                     ylabel_text = f"{ylabel_text} relative to {normalized_against}"
 
             if col_idx == 0:


### PR DESCRIPTION
Fix case when `normalized_against` is an `np.bool(False)`, where the current check erroneously adds the "relative to ..." string to the label.

Bug introduced here: 005a2f535e40ea1386ed39c567cc4c413e6f73d6

pandas dataframes implicitly convert `False` to `np.bool(False)` when assigning built-in boolean types to the column of a dataframe. So this: `agg_df["Normalized"] = False` is really doing this: `agg_df["Normalized"] = np.bool(False)`