### PR TITLE
Migrate from pynvml to cuda.core.system

### DIFF
--- a/nsight/thermovision.py
+++ b/nsight/thermovision.py
@@ -258,7 +258,9 @@ class ThermalController:
         Returns:
             GPU temperature in degrees Celsius
         """
-        return int(self.device.temperature.sensor(system.TemperatureSensors.TEMPERATURE_GPU))
+        return int(
+            self.device.temperature.sensor(system.TemperatureSensors.TEMPERATURE_GPU)
+        )
 
     def _is_temp_retrieval_supported(self) -> bool:
         """Check if GPU supports temperature retrieval.

--- a/nsight/thermovision.py
+++ b/nsight/thermovision.py
@@ -7,7 +7,8 @@ from typing import Any, Literal
 from nsight.exceptions import CoolingTimeoutError
 
 """
-This module provides GPU thermal monitoring and throttling prevention using NVIDIA's NVML library.
+This module provides GPU thermal monitoring and throttling prevention using NVIDIA's NVML library
+(as exposed through cuda.core.system).
 
 It monitors GPU temperature and T.limit, and delays execution when the GPU
 is too hot to avoid thermal throttling. The module uses an adaptive approach that
@@ -16,20 +17,13 @@ learns optimal cooling thresholds based on workload characteristics.
 
 # Guard NVML imports
 try:
-    from pynvml import (
-        NVML_TEMPERATURE_GPU,
-        NVMLError_NotSupported,
-        nvmlDeviceGetHandleByIndex,
-        nvmlDeviceGetMarginTemperature,
-        nvmlDeviceGetTemperature,
-        nvmlInit,
-    )
+    from cuda.core import system
 
-    PYNVML_AVAILABLE = True
+    CUDA_CORE_AVAILABLE = True
 except ImportError:
-    PYNVML_AVAILABLE = False
+    CUDA_CORE_AVAILABLE = False
     print(
-        "Warning: Cannot import pynvml (provided by nvidia-ml-py). Ensure nsight-python was installed properly with all dependencies."
+        "Warning: Cannot import cuda.core. Ensure nsight-python was installed properly with all dependencies."
     )
 
 # Default thermal threshold constants
@@ -110,12 +104,11 @@ class ThermalController:
         Returns:
             True if temperature retrieval is supported, False otherwise.
         """
-        if not PYNVML_AVAILABLE:
+        if not CUDA_CORE_AVAILABLE:
             return False
 
-        if self.handle is None:
-            nvmlInit()
-            self.handle = nvmlDeviceGetHandleByIndex(0)
+        if self.device is None:
+            self.device = system.Device(index=0)
 
         return self._is_temp_retrieval_supported()
 
@@ -252,8 +245,8 @@ class ThermalController:
             Thermal headroom in degrees Celsius, or None if not supported
         """
         try:
-            return nvmlDeviceGetMarginTemperature(self.handle)  # type: ignore[no-any-return]
-        except NVMLError_NotSupported as e:
+            self.device.temperature.margin
+        except system.NotSupportedError as e:
             print("Error: GPU does not support temperature limit retrieval:", e)
             return None
         except Exception as e:
@@ -265,7 +258,7 @@ class ThermalController:
         Returns:
             GPU temperature in degrees Celsius
         """
-        return nvmlDeviceGetTemperature(self.handle, NVML_TEMPERATURE_GPU)  # type: ignore[no-any-return]
+        return self.device.temperature.sensor(system.TemperatureSensors.TEMPERATURE_GPU)
 
     def _is_temp_retrieval_supported(self) -> bool:
         """Check if GPU supports temperature retrieval.
@@ -274,7 +267,7 @@ class ThermalController:
             True if supported, False otherwise
         """
         try:
-            nvmlDeviceGetMarginTemperature(self.handle)
+            self.device.temperature.margin
             return True
         except Exception:
             print(

--- a/nsight/thermovision.py
+++ b/nsight/thermovision.py
@@ -74,7 +74,7 @@ class ThermalController:
             verbose: Whether to print thermal messages.
                 Default: False
         """
-        self.handle: Any = None
+        self.device: Any = None
         self.thermal_mode = thermal_mode
 
         # Set adaptive_mode based on thermal_mode

--- a/nsight/thermovision.py
+++ b/nsight/thermovision.py
@@ -245,7 +245,7 @@ class ThermalController:
             Thermal headroom in degrees Celsius, or None if not supported
         """
         try:
-            self.device.temperature.margin
+            return self.device.temperature.margin
         except system.NotSupportedError as e:
             print("Error: GPU does not support temperature limit retrieval:", e)
             return None
@@ -258,7 +258,7 @@ class ThermalController:
         Returns:
             GPU temperature in degrees Celsius
         """
-        return self.device.temperature.sensor(system.TemperatureSensors.TEMPERATURE_GPU)
+        return int(self.device.temperature.sensor(system.TemperatureSensors.TEMPERATURE_GPU))
 
     def _is_temp_retrieval_supported(self) -> bool:
         """Check if GPU supports temperature retrieval.

--- a/nsight/thermovision.py
+++ b/nsight/thermovision.py
@@ -245,7 +245,7 @@ class ThermalController:
             Thermal headroom in degrees Celsius, or None if not supported
         """
         try:
-            return self.device.temperature.margin
+            return int(self.device.temperature.margin)
         except system.NotSupportedError as e:
             print("Error: GPU does not support temperature limit retrieval:", e)
             return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ dependencies = [
   "matplotlib",
   "ncu-report",
   "deepdiff",
-  "cuda-core>=0.7.0"
+  "cuda-core>=0.7.0",
+  "cuda-bindings>=12.9.6,!=13.0.*,!=13.1.*",
 ]
 
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,9 +20,9 @@ dependencies = [
   "pandas",
   "numpy",
   "matplotlib",
-  "nvidia-ml-py",
   "ncu-report",
   "deepdiff",
+  "cuda-core>=0.7.0"
 ]
 
 classifiers = [


### PR DESCRIPTION
This migrates nsight-python from using pynvml to [cuda.core.system](https://nvidia.github.io/cuda-python/cuda-core/latest/api.html#cuda-system-information-and-nvidia-management-library-nvml).  cuda.core.system is the new wrapper for NVML based on cybind and Cython that has much lower runtime overhead and better memory safety than the ctypes-based pynvml.