### PR TITLE
Add support for units

### DIFF
--- a/examples/00_minimal.py
+++ b/examples/00_minimal.py
@@ -36,7 +36,7 @@ def main() -> None:
     result = benchmark_matmul(1024)
     print(
         result.to_dataframe()[
-            ["Annotation", "n", "Metric", "AvgValue", "NumRuns", "GPU"]
+            ["Annotation", "n", "Metric", "Unit", "AvgValue", "NumRuns", "GPU"]
         ]
     )
     print("Benchmark complete!")

--- a/examples/03_custom_metrics.py
+++ b/examples/03_custom_metrics.py
@@ -15,14 +15,15 @@ New concepts:
 
 Additional insights on `derive_metric` usage patterns:
 1. `derive_metric` can return either:
-   - A single scalar value (e.g., TFLOPS)
-   - A dictionary containing one or more derived metrics (e.g., {"TFLOPS": value} or
-     {"TFLOPS": value, "ArithIntensity": value})
+   - A single tuple (value, unit) (e.g., (tflops, "TFLOPS"))
+   - A dictionary containing one or more derived metrics, where each value is a tuple (value, unit)
+     (e.g., {"TFLOPS": (tflops, "TFLOPS"), "ArithIntensity": (intensity, "FLOP/byte")})
+   - Note: Returning scalars without units will issue warnings and store np.nan in the Unit column
 2. When using `derive_metric`, plotting requires explicit metric specification:
    - Without `derive_metric`: Only one collected metric exists -> plot(metric=None) works
    - With `derive_metric`: Multiple metrics exist -> MUST specify which metric to plot
 3. How to specify which metric to plot in different scenarios:
-   - For scalar returns: plot(metric="function_name")
+   - For tuple returns: plot(metric="function_name")
    - For dictionary returns: plot(metric="dictionary_key")
 """
 
@@ -39,17 +40,17 @@ sizes = [(2**i,) for i in range(11, 14)]
 # ------------------------------------------------------------------------------
 
 
-def compute_tflops(time_ns: float, n: int) -> float:
+def compute_tflops(time_ns: float, n: int) -> tuple[float, str]:
     """
     Compute TFLOPS for matrix multiplication.
 
-    This function demonstrates the first pattern: returning a single scalar value.
+    This function demonstrates the first pattern: returning a single value with unit.
 
     Function signature convention for `derive_metric`:
     - First argument: the measured base metric (default: gpu__time_duration.sum in nanoseconds)
     - Remaining arguments: must match the decorated function's parameters
 
-    Note: When `derive_metric` returns a single value, the plot decorator's
+    Note: When `derive_metric` returns a tuple (value, unit), the plot decorator's
     `metric` parameter must be set to the FUNCTION NAME (as a string,
     "compute_tflops" in this case).
 
@@ -58,7 +59,7 @@ def compute_tflops(time_ns: float, n: int) -> float:
         n: Matrix size (n x n) - matches benchmark_tflops parameter
 
     Returns:
-        TFLOPS (higher is better)
+        Tuple of (TFLOPS value, unit string) - higher is better
     """
     # Matrix multiplication FLOPs: 2 * n^3 (n^3 multiplications + n^3 additions)
     flops = 2 * n * n * n
@@ -66,15 +67,13 @@ def compute_tflops(time_ns: float, n: int) -> float:
     # Compute TFLOPS
     tflops = flops / (time_ns / 1e9) / 1e12
 
-    # This function can also return a directory of one metric, such as
-    # {"TFLOPS": tflops}, but the "metric" of the plot decorator must be
-    # set to "TFLOPS" instead of "compute_tflops".
-    return tflops
+    # Return tuple with value and unit
+    return (tflops, "TFLOPS")
 
 
 @nsight.analyze.plot(
     filename="03_custom_metrics_tflops.png",
-    metric="compute_tflops",  # Must match the function name of `derive_metric` when returning scalar
+    metric="compute_tflops",  # Must match the function name of `derive_metric` when returning tuple
     ylabel="Performance (TFLOPS)",
     annotate_points=True,
 )
@@ -86,12 +85,13 @@ def benchmark_tflops(n: int) -> None:
     Benchmark matrix multiplication and display results in TFLOPS.
 
     This example shows:
-    - When `derive_metric` returns a single value, the plot metric parameter
+    - When `derive_metric` returns a tuple (value, unit), the plot metric parameter
       must be the function name ("compute_tflops")
     - Without `derive_metric`, there's only one collected metric (time duration),
       we don't need to specify a metric because plot(metric=None) works by default
     - With `derive_metric`, we have >1 metrics (time duration + derived), so we must
       explicitly specify which metric to plot
+    - Units are stored in the dataframe's "Unit" column for proper tracking
     """
     a = torch.randn(n, n, device="cuda")
     b = torch.randn(n, n, device="cuda")
@@ -105,26 +105,26 @@ def benchmark_tflops(n: int) -> None:
 # ------------------------------------------------------------------------------
 
 
-def compute_tflops_and_arithmetic_intensity(time_ns: float, n: int) -> dict[str, float]:
+def compute_tflops_and_arithmetic_intensity(
+    time_ns: float, n: int
+) -> dict[str, tuple[float, str]]:
     """
     Compute both TFLOPS and Arithmetic Intensity for matrix multiplication.
 
     This function demonstrates the second pattern: returning a dictionary
-    containing multiple derived metrics.
+    containing multiple derived metrics with units.
 
     Important: When derive_metric returns a dictionary, the plot decorator's
     `metric` parameter must be set to a KEY from the dictionary (as a string).
-
-    Note: A single scalar value could also be returned as a dictionary with
-    one key-value pair for consistency, but returning the scalar directly is
-    more concise.
 
     Args:
         time_ns: Kernel execution time in nanoseconds (automatically passed)
         n: Matrix size (n x n) - matches benchmark_tflops parameter
 
     Returns:
-        Dictionary with two metrics (TFLOPS and ArithIntensity)
+        Dictionary with two metrics, each as a tuple (value, unit):
+        - "TFLOPS": (value, "TFLOPS")
+        - "ArithIntensity": (value, "FLOP/byte")
     """
     # Matrix multiplication FLOPs: 2 * n^3
     flops = 2 * n * n * n
@@ -141,8 +141,8 @@ def compute_tflops_and_arithmetic_intensity(time_ns: float, n: int) -> dict[str,
     arithmetic_intensity = flops / memory_bytes
 
     return {
-        "TFLOPS": tflops,
-        "ArithIntensity": arithmetic_intensity,
+        "TFLOPS": (tflops, "TFLOPS"),
+        "ArithIntensity": (arithmetic_intensity, "FLOP/byte"),
     }
 
 

--- a/examples/04_multi_parameter.py
+++ b/examples/04_multi_parameter.py
@@ -29,7 +29,7 @@ dtypes = [torch.float32, torch.float16]
 configs = list(itertools.product(sizes, dtypes))
 
 
-def compute_tflops(time_ns: float, *conf: Any) -> dict[str, float]:
+def compute_tflops(time_ns: float, *conf: Any) -> dict[str, tuple[float, str]]:
     """
     Compute TFLOPs/s.
 
@@ -45,7 +45,7 @@ def compute_tflops(time_ns: float, *conf: Any) -> dict[str, float]:
 
     flops = 2 * n * n * n
     tflops: float = flops / (time_ns / 1e9) / 1e12
-    return {"TFLOPS": tflops}
+    return {"TFLOPS": (tflops, "TFLOPS")}
 
 
 @nsight.analyze.plot(

--- a/examples/05_subplots.py
+++ b/examples/05_subplots.py
@@ -28,12 +28,12 @@ transpose = [False, True]
 configs = list(itertools.product(sizes, dtypes, transpose))
 
 
-def compute_tflops(time_ns: float, *conf: Any) -> dict[str, float]:
+def compute_tflops(time_ns: float, *conf: Any) -> dict[str, tuple[float, str]]:
     """Compute TFLOPs/s using *conf to extract only what we need."""
     n: int = conf[0]  # Extract size (dtype and transpose not needed)
     flops = 2 * n * n * n
     tflops: float = flops / (time_ns / 1e9) / 1e12
-    return {"TFLOPS": tflops}
+    return {"TFLOPS": (tflops, "TFLOPS")}
 
 
 @nsight.analyze.plot(

--- a/examples/06_plot_customization.py
+++ b/examples/06_plot_customization.py
@@ -22,9 +22,10 @@ import nsight
 sizes = [(2**i,) for i in range(11, 14)]
 
 
-def compute_tflops(time_ns: float, n: int) -> dict[str, float]:
+def compute_tflops(time_ns: float, n: int) -> dict[str, tuple[float, str]]:
     flops = 2 * n * n * n
-    return {"TFLOPS": flops / (time_ns / 1e9) / 1e12}
+    tflops = flops / (time_ns / 1e9) / 1e12
+    return {"TFLOPS": (tflops, "TFLOPS")}
 
 
 # Example 1: Bar chart

--- a/examples/07_triton_minimal.py
+++ b/examples/07_triton_minimal.py
@@ -66,7 +66,7 @@ block_sizes = [256, 512, 1024, 2048]
 configs = list(itertools.product(sizes, block_sizes))
 
 
-def speedup(metric: float, n: int, block_size: int) -> float:
+def speedup(metric: float, n: int, block_size: int) -> tuple[float, str]:
     """
     Compute speedup from normalized timing metric.
 
@@ -79,9 +79,9 @@ def speedup(metric: float, n: int, block_size: int) -> float:
         block_size: Triton block size parameter
 
     Returns:
-        Speedup value (baseline / current)
+        Tuple of (speedup value, unit) - speedup is unitless, represented as "x"
     """
-    return 1.0 / metric
+    return (1.0 / metric, "x")
 
 
 @nsight.analyze.plot(

--- a/examples/09_advanced_metric_custom.py
+++ b/examples/09_advanced_metric_custom.py
@@ -20,7 +20,7 @@ sizes = [(2**i,) for i in range(10, 12)]
 
 def compute_insts_statistics(
     ld_insts: int, st_insts: int, launch_sm_count: int, n: int
-) -> dict[str, float]:
+) -> dict[str, tuple[float, str]]:
     """
     Compute shared memory instruction statistics per SM.
 
@@ -45,11 +45,11 @@ def compute_insts_statistics(
         n: Matrix size (n x n) - parameter from the decorated benchmark function
 
     Returns:
-        Dictionary containing four derived metrics:
-        - "ld_insts_per_sm": Average load instructions per SM
-        - "st_insts_per_sm": Average store instructions per SM
-        - "insts_total": Total shared memory instructions (load + store)
-        - "insts_per_sm": Average total instructions per SM
+        Dictionary containing four derived metrics, each as a tuple (value, unit):
+        - "ld_insts_per_sm": (value, "inst/SM")
+        - "st_insts_per_sm": (value, "inst/SM")
+        - "insts_total": (value, "inst")
+        - "insts_per_sm": (value, "inst/SM")
     """
     ld_insts_per_sm = ld_insts / launch_sm_count
     st_insts_per_sm = st_insts / launch_sm_count
@@ -57,10 +57,10 @@ def compute_insts_statistics(
     insts_per_sm = (ld_insts + st_insts) / launch_sm_count
 
     return {
-        "ld_insts_per_sm": ld_insts_per_sm,
-        "st_insts_per_sm": st_insts_per_sm,
-        "insts_total": insts_total,
-        "insts_per_sm": insts_per_sm,
+        "ld_insts_per_sm": (ld_insts_per_sm, "inst/SM"),
+        "st_insts_per_sm": (st_insts_per_sm, "inst/SM"),
+        "insts_total": (insts_total, "inst"),
+        "insts_per_sm": (insts_per_sm, "inst/SM"),
     }
 
 

--- a/nsight/analyze.py
+++ b/nsight/analyze.py
@@ -7,7 +7,7 @@ import os
 import tempfile
 import warnings
 from collections.abc import Callable, Iterable, Sequence
-from typing import Any, Literal, overload
+from typing import Any, Literal, Mapping, overload
 
 import matplotlib
 import matplotlib.figure
@@ -32,7 +32,12 @@ def kernel(
     *,
     configs: Iterable[Any] | None = None,
     runs: int = 1,
-    derive_metric: Callable[..., float | dict[str, float]] | None = None,
+    derive_metric: (
+        Callable[
+            ..., float | tuple[float, str] | Mapping[str, float | tuple[float, str]]
+        ]
+        | None
+    ) = None,
     normalize_against: str | None = None,
     output: Literal["quiet", "progress", "verbose"] = "progress",
     metrics: Sequence[str] = ["gpu__time_duration.sum"],
@@ -56,7 +61,12 @@ def kernel(
     *,
     configs: Iterable[Any] | None = None,
     runs: int = 1,
-    derive_metric: Callable[..., float | dict[str, float]] | None = None,
+    derive_metric: (
+        Callable[
+            ..., float | tuple[float, str] | Mapping[str, float | tuple[float, str]]
+        ]
+        | None
+    ) = None,
     normalize_against: str | None = None,
     output: Literal["quiet", "progress", "verbose"] = "progress",
     metrics: Sequence[str] = ["gpu__time_duration.sum"],
@@ -126,12 +136,17 @@ def kernel(
             metrics. Return value can be either:
 
             - A single value (float/int): Will be added as a new metric with the function name as the metric name. For lambda functions, the metric name will be ``"<lambda>"``.
-            - A dictionary: Keys will be used as metric names, values as metric values.
+            - A tuple (value, unit): A single metric value with its unit specified. The value will be added with the function name as the metric name, and the unit will be stored in the ``Unit`` column of the dataframe. Example: ``(tflops_value, "TFLOPS")``.
+            - A dictionary: Keys will be used as metric names, values can be either:
+                - Scalar values (float/int): Metric values without units. ``np.nan`` will be added to the ``Unit`` column and a warning will be issued.
+                - Tuples (value, unit): Metric values with units specified. The unit will be stored in the ``Unit`` column of the dataframe. Example: ``{"TFLOPS": (tflops_value, "TFLOPS"), "ArithIntensity": (intensity_value, "FLOP/byte")}``.
 
             The parameter order requirements for the custom function:
 
             - First several arguments: Must exactly match the order of metrics declared in the @kernel decorator. These arguments will receive the actual measured values of those metrics.
             - Remaining arguments: Must exactly match the signature of the decorated function. In other words, the original function's parameters are passed in order.
+
+            **Note on units**: When units are not provided (returning scalar values instead of tuples), ``np.nan`` will be added to the ``Unit`` column in the dataframe and a warning will be issued. To avoid warnings and ensure proper unit tracking, return tuples ``(value, unit)`` for all derived metrics.
 
             See the examples for concrete use cases.
         normalize_against:
@@ -232,6 +247,7 @@ def kernel(
                 - ``Annotation``: Name of the annotated region being profiled
                 - ``Value``: Raw metric values collected by the profiler
                 - ``Metric``: The metrics being collected (e.g., ``gpu__time_duration.sum``) and the metrics being derived
+                - ``Unit``: Unit of measurement for the metric value (e.g., ``ns`` for nanoseconds)
                 - ``Kernel``: Name of the GPU kernel(s) launched
                 - ``GPU``: GPU device name
                 - ``Host``: Host machine name
@@ -253,6 +269,7 @@ def kernel(
                 - ``RelativeStdDevPct``: Standard deviation as a percentage of the mean
                 - ``StableMeasurement``: Boolean indicating if the measurement is stable (low variance). The measurement is stable if ``RelativeStdDevPct`` < 2 % .
                 - ``Metric``: The metrics being collected and the metrics being derived
+                - ``Unit``: Unit of measurement for the metric value (e.g., ``ns`` for nanoseconds)
                 - ``Kernel``: Name of the GPU kernel(s) launched
                 - ``GPU``: GPU device name
                 - ``Host``: Host machine name

--- a/nsight/collection/core.py
+++ b/nsight/collection/core.py
@@ -11,7 +11,7 @@ import threading
 import time
 import warnings
 from collections.abc import Callable, Collection, Iterable, Sequence
-from typing import Any, List, Literal
+from typing import Any, List, Literal, Mapping
 
 import numpy as np
 import pandas as pd
@@ -387,7 +387,12 @@ class ProfileSettings:
     Will display a progress bar, detailed output for each config along with the profiler logs
     """
 
-    derive_metric: Callable[..., float | dict[str, float]] | None
+    derive_metric: (
+        Callable[
+            ..., float | tuple[float, str] | Mapping[str, float | tuple[float, str]]
+        ]
+        | None
+    )
     """
     A function to transform the collected metrics.
     This can be used to compute derived metrics like TFLOPs that cannot
@@ -502,6 +507,7 @@ class ProfileResults:
                 - ``RelativeStdDevPct``: Standard deviation as a percentage of the mean
                 - ``StableMeasurement``: Boolean indicating if the measurement is stable (low variance). The measurement is stable if ``RelativeStdDevPct`` < 2 % .
                 - ``Metric``: The metrics being collected and the metrics being derived
+                - ``Unit``: Unit of measurement for the metric value (e.g., ``ns`` for nanoseconds)
                 - ``Kernel``: Name of the GPU kernel(s) launched
                 - ``GPU``: GPU device name
                 - ``Host``: Host machine name

--- a/nsight/extraction.py
+++ b/nsight/extraction.py
@@ -18,19 +18,27 @@ Functions:
 import functools
 import inspect
 import socket
-from collections.abc import Callable, Sequence
+import warnings
+from collections.abc import Callable, Mapping, Sequence
 from typing import Any, List, Tuple, TypeAlias
 
 import ncu_report
 import numpy as np
 import pandas as pd
-from numpy.typing import NDArray
 
 from nsight import exceptions, utils
 from nsight.utils import is_scalar
 
 DerivedValue: TypeAlias = float | int | None
-DerivedValueDict: TypeAlias = dict[str, DerivedValue]
+DerivedValueWithUnit: TypeAlias = tuple[DerivedValue, str]
+DerivedValueDict: TypeAlias = Mapping[str, DerivedValue | DerivedValueWithUnit]
+
+# Warning message template for missing units in derived metrics
+DERIVED_METRIC_MISSING_UNIT_WARNING = (
+    "Derived metric '{}' does not have a unit specified. "
+    "Return a tuple (value, unit) instead of just the value. "
+    "np.nan will be added to the 'Unit' column in the dataframe."
+)
 
 
 def extract_ncu_action_data(action: Any, metrics: Sequence[str]) -> utils.NCUActionData:
@@ -56,6 +64,7 @@ def extract_ncu_action_data(action: Any, metrics: Sequence[str]) -> utils.NCUAct
     all_values = (
         None if failure else np.array([action[metric].value() for metric in metrics])
     )
+    all_units = [action[metric].unit() for metric in metrics]
 
     return utils.NCUActionData(
         name=action.name(),
@@ -63,6 +72,7 @@ def extract_ncu_action_data(action: Any, metrics: Sequence[str]) -> utils.NCUAct
         compute_clock=action["device__attribute_clock_rate"].value(),
         memory_clock=action["device__attribute_memory_clock_rate"].value(),
         gpu=action["device__attribute_display_name"].value(),
+        units=all_units,
     )
 
 
@@ -111,8 +121,9 @@ def extract_df_from_report(
     annotations: List[str] = []
     all_values: List[Tuple[Any, ...] | None] = []
     all_transformed_values: List[
-        List[DerivedValue] | DerivedValue | NDArray[Any] | None
+        List[DerivedValue] | DerivedValue | np.typing.NDArray[Any] | None
     ] = []
+    all_transformed_values_units: list[List[str | float] | str | float] = []
     kernel_names: List[str] = []
     gpus: List[str] = []
     compute_clocks: List[int] = []
@@ -120,6 +131,7 @@ def extract_df_from_report(
     all_metrics: List[Tuple[str, ...]] = []
     all_transformed_metrics: List[List[str] | str | bool] = []
     hostnames: List[str] = []
+    units: List[List[str]] = []
 
     sig = inspect.signature(func)
 
@@ -213,6 +225,7 @@ def extract_df_from_report(
             memory_clocks.append(data.memory_clock)
             gpus.append(data.gpu)
             kernel_names.append(data.name)
+            units.append(data.units)
 
             # evaluate the measured metrics
             values = data.values
@@ -237,22 +250,53 @@ def extract_df_from_report(
                                 f"but has {actual_params} parameters"
                             )
 
-                derived_metric: DerivedValueDict | DerivedValue = (
-                    None if values is None else derive_metric(*values, *conf)
-                )
-                if isinstance(derived_metric, dict):
+                # Store function name for warning messages
+                derive_metric_func_name = derive_metric.__name__
+                derived_metric: (
+                    DerivedValueWithUnit | DerivedValueDict | DerivedValue
+                ) = (None if values is None else derive_metric(*values, *conf))
+                if isinstance(derived_metric, Mapping):
                     # If the derived metric is a dict, then we have multiple metrics
                     # and use the keys of the dict as metric names.
-                    metric_names, metric_values = zip(
-                        *[(k, v) for k, v in derived_metric.items()]
-                    )
+
+                    metric_names: list[str] = list()
+                    metric_values: list[DerivedValue] = list()
+                    unit_names: list[str | float] = list()
+
+                    for metric_name, metric_value in derived_metric.items():
+                        metric_names.append(metric_name)
+
+                        if isinstance(metric_value, tuple) and len(metric_value) >= 2:
+                            metric_values.append(metric_value[0])
+                            unit_names.append(metric_value[1])
+                        else:
+                            # It is a scalar value
+                            metric_values.append(metric_value)
+                            unit_names.append(np.nan)
+                            warnings.warn(
+                                DERIVED_METRIC_MISSING_UNIT_WARNING.format(metric_name)
+                            )
+
                     all_transformed_values.append(list(metric_values))
                     all_transformed_metrics.append(list(metric_names))
+                    all_transformed_values_units.append(list(unit_names))
+
                 else:
-                    # If the derived metric is a scalar, then we have a single metric
-                    # and use the name of the function as the metric name.
-                    all_transformed_values.append(derived_metric)
-                    all_transformed_metrics.append(derive_metric.__name__)
+                    if isinstance(derived_metric, tuple):
+                        derived_metric_value = derived_metric[0]
+                        derived_metric_unit = derived_metric[1]
+                        all_transformed_values.append(derived_metric_value)
+                        all_transformed_values_units.append(derived_metric_unit)
+
+                    else:
+                        warnings.warn(
+                            DERIVED_METRIC_MISSING_UNIT_WARNING.format(
+                                derive_metric_func_name
+                            )
+                        )
+                        all_transformed_values.append(derived_metric)
+                        all_transformed_values_units.append(np.nan)
+                    all_transformed_metrics.append(derive_metric_func_name)
 
             # gather remaining required data
             annotations.append(annotation)
@@ -279,15 +323,20 @@ def extract_df_from_report(
         "Host": hostnames,
         "ComputeClock": compute_clocks,
         "MemoryClock": memory_clocks,
+        "Unit": units,
     }
 
     # Add each array in arg_arrays to the DataFrame
     for arg_name, arg_values in arg_arrays.items():
         df_data[arg_name] = arg_values
 
-    # Explode only Value and Metric columns (which contain tuples of per-metric data).
+    # Explode only Value, Metric and Unit columns (which contain tuples of per-metric data).
     # Other columns (including function args) may also contain tuples that should NOT be exploded.
-    df = pd.DataFrame(df_data).explode(["Value", "Metric"]).reset_index(drop=True)
+    df = (
+        pd.DataFrame(df_data)
+        .explode(["Value", "Metric", "Unit"])
+        .reset_index(drop=True)
+    )
 
     if derive_metric is not None:
         transformed_df_data = {
@@ -299,6 +348,7 @@ def extract_df_from_report(
             "Host": hostnames,
             "ComputeClock": compute_clocks,
             "MemoryClock": memory_clocks,
+            "Unit": all_transformed_values_units,
         }
 
         for arg_name, arg_values in arg_arrays.items():
@@ -306,7 +356,7 @@ def extract_df_from_report(
 
         transformed_df = (
             pd.DataFrame(transformed_df_data)
-            .explode(["Value", "Metric"])
+            .explode(["Value", "Metric", "Unit"])
             .reset_index(drop=True)
         )
 

--- a/nsight/utils.py
+++ b/nsight/utils.py
@@ -138,6 +138,7 @@ class NCUActionData:
     compute_clock: int
     memory_clock: int
     gpu: str
+    units: list[str]
 
     @staticmethod
     def combine(value_reduce_op: Any) -> Any:
@@ -150,12 +151,14 @@ class NCUActionData:
             assert lhs.compute_clock == rhs.compute_clock
             assert lhs.memory_clock == rhs.memory_clock
             assert lhs.gpu == rhs.gpu
+            assert lhs.units == rhs.units
             return NCUActionData(
                 name=f"{lhs.name}|{rhs.name}",
                 values=value_reduce_op(lhs.values, rhs.values),
                 compute_clock=lhs.compute_clock,
                 memory_clock=lhs.memory_clock,
                 gpu=lhs.gpu,
+                units=lhs.units,
             )
 
         return _combine

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
   "pandas",
   "numpy",
   "matplotlib",
-  "ncu-report",
+  "ncu-report>=2026.2.0",
   "deepdiff",
   "cuda-core>=0.7.0",
   "cuda-bindings>=12.9.6,!=13.0.*,!=13.1.*",

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
-
 """
 Test suite for Nsight Python profiler functionality.
 """
@@ -10,6 +7,8 @@ import shutil
 from collections.abc import Generator, Sequence
 from typing import Any, Literal
 
+import numpy as np
+import pandas as pd
 import pytest
 import torch
 from cuda.core import Device, LaunchConfig, Program, launch
@@ -749,9 +748,9 @@ def test_parameter_ignore_kernel_list(ignore_kernel_list: None | list[str]) -> N
 
         # Allocate device memory
         size_bytes = n * 4  # float32
-        d_a = device.allocate(size_bytes)
-        d_b = device.allocate(size_bytes)
-        d_c = device.allocate(size_bytes)
+        d_a = device.allocate(size_bytes, stream=s)
+        d_b = device.allocate(size_bytes, stream=s)
+        d_c = device.allocate(size_bytes, stream=s)
 
         # Launch both kernels in one annotation
         with nsight.annotate(f"test_kernels_{ignore_kernel_list}"):
@@ -906,9 +905,9 @@ def test_parameter_replay_mode(
 
             # Allocate device memory
             size_bytes = n * 4  # float32
-            d_a = device.allocate(size_bytes)
-            d_b = device.allocate(size_bytes)
-            d_c = device.allocate(size_bytes)
+            d_a = device.allocate(size_bytes, stream=s)
+            d_b = device.allocate(size_bytes, stream=s)
+            d_c = device.allocate(size_bytes, stream=s)
 
             # Launch multiple kernels in the same annotation
             with nsight.annotate("test_replay"):
@@ -942,7 +941,7 @@ def test_parameter_replay_mode(
 # ============================================================================
 
 
-def _compute_custom_metric_1(time_ns: float, x: int, y: int) -> float:
+def _compute_custom_metric(time_ns: float, x: int, y: int) -> float:
     """Transform time in nanoseconds to a custom metric based on matrix size."""
     # Custom formula: operations per second (arbitrary for testing)
     operations = x * y
@@ -950,27 +949,66 @@ def _compute_custom_metric_1(time_ns: float, x: int, y: int) -> float:
     return operations / time_s if time_s > 0 else 0.0
 
 
-def _compute_custom_metric_2(time_ns: float, x: int, y: int) -> dict[str, float]:
+def _compute_custom_metric_dict(time_ns: float, x: int, y: int) -> dict[str, float]:
     """Transform time in nanoseconds to a custom metric based on matrix size."""
     # Custom formula: operations per second (arbitrary for testing)
     operations = x * y
     time_s = time_ns / 1e9
-    return {"Custom Metric": operations / time_s if time_s > 0 else 0.0}
+    throughput = operations / time_s if time_s > 0 else 0.0
+    efficiency = throughput / 1e6 if throughput > 0 else 0.0
+    return {
+        "CustomMetric1": throughput,
+        "CustomMetric2": efficiency,
+    }
+
+
+def _compute_custom_metric_with_unit(
+    time_ns: float, x: int, y: int
+) -> tuple[float, str]:
+    """Compute custom metric and return with unit."""
+    value = _compute_custom_metric(time_ns, x, y)
+    return (value, "ops/s")
+
+
+def _compute_custom_metrics_dict_with_units(
+    time_ns: float, x: int, y: int
+) -> dict[str, tuple[float, str]]:
+    """Compute multiple custom metrics and return with units."""
+    base_dict = _compute_custom_metric_dict(time_ns, x, y)
+    return {
+        "CustomMetric1": (base_dict["CustomMetric1"], "ops/s"),
+        "CustomMetric2": (base_dict["CustomMetric2"], "Mops/s"),
+    }
 
 
 @pytest.mark.parametrize(
-    "derive_metric_func,expected_name",
+    "derive_metric_func,expected_name,expected_units",
     [
-        (_compute_custom_metric_1, "_compute_custom_metric_1"),
-        (_compute_custom_metric_2, "Custom Metric"),
-        (lambda time_ns, x, y: (x * y) / (time_ns / 1e9) / 1e9, "<lambda>"),
+        (_compute_custom_metric, "_compute_custom_metric", [None]),
+        (_compute_custom_metric_dict, ["CustomMetric1", "CustomMetric2"], [None, None]),
+        (lambda time_ns, x, y: (x * y) / (time_ns / 1e9) / 1e9, "<lambda>", [None]),
         (
             lambda time_ns, x, y: {"Custom Metric": (x * y) / (time_ns / 1e9) / 1e9},
             "Custom Metric",
+            [None],
+        ),
+        (
+            _compute_custom_metric_with_unit,
+            "_compute_custom_metric_with_unit",
+            ["ops/s"],
+        ),
+        (
+            _compute_custom_metrics_dict_with_units,
+            ["CustomMetric1", "CustomMetric2"],
+            ["ops/s", "Mops/s"],
         ),
     ],
 )  # type: ignore[untyped-decorator]
-def test_parameter_derive_metric(derive_metric_func: Any, expected_name: str) -> None:
+def test_parameter_derive_metric(
+    derive_metric_func: Any,
+    expected_name: str | list[str],
+    expected_units: list[str | None],
+) -> None:
     """Test the derive_metric parameter to transform collected metrics."""
 
     configs = [(100, 100), (200, 200)]
@@ -987,7 +1025,15 @@ def test_parameter_derive_metric(derive_metric_func: Any, expected_name: str) ->
         _simple_kernel_impl(x, y, "test_derive_metric")
 
     # Run profiling
-    profile_output = profiled_func()
+    # Check for warnings when units are None
+    has_none_units = any(unit is None for unit in expected_units)
+    if has_none_units:
+        with pytest.warns(
+            UserWarning, match="Derived metric.*does not have a unit specified"
+        ):
+            profile_output = profiled_func()
+    else:
+        profile_output = profiled_func()
     assert profile_output is not None, "ProfileResults should be returned"
 
     # Verify the transformed metric is present
@@ -997,16 +1043,53 @@ def test_parameter_derive_metric(derive_metric_func: Any, expected_name: str) ->
         df["Metric"][0:raw_metric_rows] == "gpu__time_duration.sum"
     ), f"Metric column (row-{0} ~ row-{raw_metric_rows-1}) should show 'gpu__time_duration.sum'"
 
-    assert all(
-        df["Metric"][raw_metric_rows : len(df)] == expected_name
-    ), f"Metric column (row-{raw_metric_rows} ~ row-{len(df)-1}) should show '{expected_name}'"
+    # Handle dictionary return case separately
+    if isinstance(expected_name, list):
+        # For dictionary returns, check that all expected metrics are present
+        expected_metrics = set(expected_name)
+        derived_metrics = set(df["Metric"][raw_metric_rows:].unique())
+        assert expected_metrics.issubset(
+            derived_metrics
+        ), f"Expected metrics {expected_metrics} not all found in {derived_metrics}"
+        # Verify we have results for all combinations (2 configs * (1 base + N derived) metrics)
+        expected_rows = len(configs) * (1 + len(expected_name))
+        assert (
+            len(df) == expected_rows
+        ), f"Should have results for {expected_rows} rows (2 configs * {1 + len(expected_name)} metrics)"
+    else:
+        assert all(
+            df["Metric"][raw_metric_rows : len(df)] == expected_name
+        ), f"Metric column (row-{raw_metric_rows} ~ row-{len(df)-1}) should show '{expected_name}'"
+        # Verify we have results for all combinations (2 configs * 2 metrics = 4 rows)
+        assert len(df) == 2 * 2, "Should have results for 2 configurations * 2 metrics"
 
     # Verify the metric values are transformed (should be positive numbers)
     assert "AvgValue" in df.columns, "AvgValue column should exist"
-    assert all(df["AvgValue"] > 0), "All derived metric values should be positive"
 
-    # Verify we have results for all combinations (2 configs * 2 metrics = 4 rows)
-    assert len(df) == 2 * 2, "Should have results for 2 configurations * 2 metrics"
+    # Check units for tuple return cases
+    assert "Unit" in df.columns, "Unit column should exist in the dataframe"
+
+    # Check units based on expected_units parameter
+    # Normalize expected_name to a list for consistent handling
+    if isinstance(expected_name, str):
+        expected_names = [expected_name]
+    else:
+        expected_names = expected_name
+
+    # Check units for each metric
+    for metric_name, expected_unit in zip(expected_names, expected_units):
+        metric_rows = df[df["Metric"] == metric_name]
+        assert len(metric_rows) > 0, f"Metric '{metric_name}' not found in results"
+        actual_units = metric_rows["Unit"].unique()
+        if expected_unit is None:
+            # When unit is None, we expect np.nan in the dataframe
+            assert len(actual_units) == 1 and pd.isna(
+                actual_units[0]
+            ), f"Invalid unit for metric '{metric_name}'. Expected np.nan, got {actual_units.tolist()}"
+        else:
+            assert (
+                len(actual_units) == 1 and actual_units[0] == expected_unit
+            ), f"Invalid unit for metric '{metric_name}'. Expected '{expected_unit}', got {actual_units.tolist()}"
 
 
 # ============================================================================
@@ -1080,14 +1163,35 @@ def test_parameter_output(
             "valid_single_zero",
             id="valid_single_zero",
         ),
+        pytest.param(
+            [
+                "sm__warps_launched.sum",
+                "gpu__time_duration.sum",
+            ],
+            "valid_multiple",
+            id="valid_multiple",
+        ),
     ],
 )
 def test_parameter_metrics(metrics: Sequence[str], expected_result: str) -> None:
 
-    @nsight.analyze.plot(filename="plot.png", ylabel="Instructions")
-    @nsight.analyze.kernel(configs=[(100, 100), (200, 200)], runs=2, metrics=metrics)
-    def profiled_func(x: int, y: int) -> None:
-        _simple_kernel_impl(x, y, "test_parameter_metrics")
+    # Don't use plot decorator for multiple metrics test
+    if expected_result == "valid_multiple":
+
+        @nsight.analyze.kernel(
+            configs=[(100, 100), (200, 200)], runs=2, metrics=metrics
+        )
+        def profiled_func(x: int, y: int) -> None:
+            _simple_kernel_impl(x, y, "test_parameter_metrics")
+
+    else:
+
+        @nsight.analyze.plot(filename="plot.png", ylabel="Instructions")
+        @nsight.analyze.kernel(
+            configs=[(100, 100), (200, 200)], runs=2, metrics=metrics
+        )
+        def profiled_func(x: int, y: int) -> None:
+            _simple_kernel_impl(x, y, "test_parameter_metrics")
 
     # Run profiling
     if expected_result == "invalid_single":
@@ -1106,6 +1210,15 @@ def test_parameter_metrics(metrics: Sequence[str], expected_result: str) -> None
         assert (
             df["Metric"] == metrics[0]
         ).all(), f"Invalid metric name {df.loc[df['Metric'] != metrics[0], 'Metric'].iloc[0]} found in output dataframe"
+
+        # Check if Unit column exists
+        assert "Unit" in df.columns, "Unit column should exist in the dataframe"
+
+        # Check unit for sm__warps_launched.sum (expected unit: "warp")
+        actual_units = df["Unit"].unique()
+        assert (
+            len(actual_units) == 1 and actual_units[0] == "warp"
+        ), f"Invalid unit for metric 'sm__warps_launched.sum'. Expected 'warp', got {actual_units.tolist()}"
 
         # Checking if the metric values are valid
         assert (
@@ -1129,6 +1242,40 @@ def test_parameter_metrics(metrics: Sequence[str], expected_result: str) -> None
             ),
         ):
             profiled_func()
+    elif expected_result == "valid_multiple":
+        profile_output = profiled_func()
+        df = profile_output.to_dataframe()
+
+        # Expected units for the metrics
+        expected_units = {
+            "sm__warps_launched.sum": "warp",
+            "gpu__time_duration.sum": "ns",
+        }
+
+        # Check if the dataframe has the right metrics
+        assert all(
+            df["Metric"].isin(metrics)
+        ), f"Invalid metric names found in output dataframe. Expected {metrics}, got {df['Metric'].unique().tolist()}"
+
+        # Check if Unit column exists
+        assert "Unit" in df.columns, "Unit column should exist in the dataframe"
+
+        # Check units for each metric
+        for metric in metrics:
+            metric_rows = df[df["Metric"] == metric]
+            assert len(metric_rows) > 0, f"Metric '{metric}' not found in results"
+
+            expected_unit = expected_units.get(metric)
+            if expected_unit is not None:
+                actual_units = metric_rows["Unit"].unique()
+                assert (
+                    len(actual_units) == 1 and actual_units[0] == expected_unit
+                ), f"Invalid unit for metric '{metric}'. Expected '{expected_unit}', got {actual_units.tolist()}"
+
+        # Check if the metric values are valid
+        assert (
+            df["AvgValue"].notna() & (df["AvgValue"] > 1)
+        ).all(), f"Invalid AvgValue for metrics {metrics}"
 
 
 # ============================================================================


### PR DESCRIPTION
Adds unit support to the pandas DataFrame returned by ProfileResults.to_dataframe() via a new "Units" column.

For metrics collected with ncu, units are parsed from the ncu report.
For derived metrics, users should now return either:

A tuple (value: int|float, unit: str), or
A dictionary whose values are tuples (value: int|float, unit: str).


Backward compatibility is maintained: returning only the metric value is still supported. In this case, a warning is emitted and the "Units" field is set to None.