### PR TITLE
add dependency for cuda-tile in pyproject.toml

### DIFF
--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -8,11 +8,6 @@ import pytest
 import torch
 
 
-def get_cuda_dev_cc_major(device_id: int) -> Any:
-    props = torch.cuda.get_device_properties(device_id)
-    return props.major
-
-
 def test_00_minimal() -> None:
     minimal = importlib.import_module("examples.00_minimal")
     minimal.main()
@@ -74,11 +69,6 @@ def test_11_output_csv() -> None:
     output_csv.main()
 
 
-# skip cuTile test on CC 9.x as Cuda Toolkit 13.2 used for testing does not support cuda-tile on CC 9.x (Hopper)
-@pytest.mark.skipif(
-    get_cuda_dev_cc_major(0) == 9,
-    reason="cuda-tile not supported on CC 9.x in CUDA Toolkit 13.2",
-)  # type: ignore[untyped-decorator]
 def test_12_cutile() -> None:
     cutile = importlib.import_module("examples.12_cutile")
     cutile.main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,10 +42,6 @@ classifiers = [
 cu12 = ["cuda-core[cu12]"]
 cu13 = ["cuda-core[cu13]"]
 
-test = [
-  "cuda-tile>=1.4.0",
-]
-
 [project.urls]
 Repository = "https://github.com/NVIDIA/nsight-python"
 License = "https://docs.nvidia.com/nsight-python/license.html"
@@ -91,6 +87,7 @@ dependencies = [
   "black",
   "isort",
   "mypy",
+  "cuda-tile>=1.4.0",
 ]
 
 [tool.hatch.envs.lint.scripts]
@@ -109,6 +106,7 @@ format = [
 dependencies = [
   "pytest",
   "pytest-cov",
+  "cuda-tile>=1.4.0",
 ]
 system-packages = true
 [tool.hatch.envs.test.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,10 @@ classifiers = [
 cu12 = ["cuda-core[cu12]"]
 cu13 = ["cuda-core[cu13]"]
 
+test = [
+  "cuda-tile>=1.4.0",
+]
+
 [project.urls]
 Repository = "https://github.com/NVIDIA/nsight-python"
 License = "https://docs.nvidia.com/nsight-python/license.html"


### PR DESCRIPTION
- add dependency for cuda-tile in pyproject.toml under optional-dependencies "test" section
- revert previous change of skipping tile example test on Hopper