### PR TITLE
Implement verbosity parameter in nsight.analyze.kernel API

### DIFF
--- a/nsight/__init__.py
+++ b/nsight/__init__.py
@@ -5,8 +5,8 @@ from importlib.metadata import version
 
 from nsight import analyze
 from nsight.annotation import annotate
-from nsight.utils import col_panel, row_panel
+from nsight.utils import VerbosityLevel, col_panel, row_panel
 
 __version__ = version("nsight-python")
 
-__all__ = ["analyze", "annotate"]
+__all__ = ["analyze", "annotate", "VerbosityLevel"]

--- a/nsight/analyze.py
+++ b/nsight/analyze.py
@@ -16,6 +16,7 @@ from numpy.typing import NDArray
 
 import nsight.collection as collection
 import nsight.visualization as visualization
+from nsight.utils import VerbosityLevel
 
 
 # Overload 1: When used without parentheses: @kernel
@@ -39,7 +40,7 @@ def kernel(
         | None
     ) = None,
     normalize_against: str | None = None,
-    output: Literal["quiet", "progress", "verbose"] = "progress",
+    verbosity: VerbosityLevel = VerbosityLevel.INFO,
     metrics: Sequence[str] = ["gpu__time_duration.sum"],
     ignore_kernel_list: Sequence[str] | None = None,
     clock_control: Literal["base", "none"] = "none",
@@ -68,7 +69,7 @@ def kernel(
         | None
     ) = None,
     normalize_against: str | None = None,
-    output: Literal["quiet", "progress", "verbose"] = "progress",
+    verbosity: VerbosityLevel = VerbosityLevel.INFO,
     metrics: Sequence[str] = ["gpu__time_duration.sum"],
     ignore_kernel_list: Sequence[str] | None = None,
     clock_control: Literal["base", "none"] = "none",
@@ -219,11 +220,14 @@ def kernel(
         thermal_timeout: Maximum wait time in seconds for GPU to cool down.
             Default: 180 seconds
 
-        output: Controls the verbosity level of the output.
+        verbosity: Controls the verbosity level of the output. Selecting level N
+            enables output at all levels with value <= N. Default: ``VerbosityLevel.INFO``.
 
-            - ``"quiet"``: Suppresses all output.
-            - ``"progress"``: Shows a progress bar along with details about profiling and data extraction progress.
-            - ``"verbose"``: Displays the progress bar, configuration-specific logs, and profiler logs.
+            - ``VerbosityLevel.SILENT``: Suppresses all output.
+            - ``VerbosityLevel.INFO``: Shows a progress bar, profiling completion messages,
+              and report file paths.
+            - ``VerbosityLevel.DEBUG``: Adds configuration-specific logs, the full NCU CLI
+              command, and enables NCU verbose output.
 
         output_prefix: When specified, all intermediate profiler files are created with this prefix.
             For example, if `output_prefix="/home/user/run1_"`, the profiler will generate:
@@ -291,12 +295,6 @@ def kernel(
 
     def _create_profiler() -> collection.core.NsightProfiler:
         """Helper to create the profiler with the given settings."""
-        if output not in ("quiet", "progress", "verbose"):
-            raise ValueError("output must be 'quiet', 'progress' or 'verbose'")
-
-        output_progress = output == "progress" or output == "verbose"
-        output_detailed = output == "verbose"
-
         # Create the output paths needed for the ncu report, ncu logs and the CSVs
         prefix = output_prefix
         if "NSPY_NCU_PROFILE" not in os.environ:
@@ -311,8 +309,7 @@ def kernel(
         settings = collection.core.ProfileSettings(
             configs=configs,
             runs=runs,
-            output_progress=output_progress,
-            output_detailed=output_detailed,
+            verbosity=verbosity,
             derive_metric=derive_metric,
             normalize_against=normalize_against,
             thermal_mode=thermal_mode,

--- a/nsight/collection/core.py
+++ b/nsight/collection/core.py
@@ -17,6 +17,7 @@ import numpy as np
 import pandas as pd
 
 from nsight import annotation, exceptions, thermovision, transformation, utils
+from nsight.utils import VerbosityLevel
 
 
 def _get_regular_params(
@@ -235,15 +236,14 @@ def run_profile_session(
     func: Callable[..., None],
     configs: List[Sequence[Any]],
     runs: int,
-    output_progress: bool,
-    output_detailed: bool,
+    verbosity: VerbosityLevel,
     thermal_mode: Literal["auto", "manual", "off"],
     thermal_wait: int | None = None,
     thermal_cont: int | None = None,
     thermal_timeout: int | None = None,
 ) -> None:
 
-    if output_progress:
+    if verbosity >= VerbosityLevel.INFO:
         print("")
         print("")
 
@@ -255,7 +255,7 @@ def run_profile_session(
             thermal_wait=thermal_wait,
             thermal_cont=thermal_cont,
             thermal_timeout=thermal_timeout,
-            verbose=output_detailed,
+            verbose=verbosity >= VerbosityLevel.DEBUG,
         )
         thermovision_initialized = thermal_controller.init()
         if not thermovision_initialized:
@@ -270,8 +270,8 @@ def run_profile_session(
     bar_length = 100
     progress_time: float = 0
 
-    # overwrite flag: we do not overwrite when output mode is detailed
-    overwrite_output = not output_detailed
+    # overwrite flag: we do not overwrite when output mode is debug
+    overwrite_output = verbosity < VerbosityLevel.DEBUG
     show_return_type_warning = False
     config_lengths: list[int] = list()
 
@@ -300,7 +300,7 @@ def run_profile_session(
 
         curr_config += 1
 
-        if output_progress:
+        if verbosity >= VerbosityLevel.INFO:
             utils.print_config(total_configs, curr_config, c, overwrite_output)
 
         for i in range(runs):
@@ -328,7 +328,7 @@ def run_profile_session(
 
             # Update time estimates every half second
             if time.time() - progress_time > 0.5:
-                if output_progress:
+                if verbosity >= VerbosityLevel.INFO:
                     utils.print_progress_bar(
                         total_runs,
                         curr_run,
@@ -339,7 +339,7 @@ def run_profile_session(
                 progress_time = time.time()
 
     # Update progress bar at end so it shows 100%
-    if output_progress:
+    if verbosity >= VerbosityLevel.INFO:
         utils.print_progress_bar(
             total_runs,
             curr_run,
@@ -377,14 +377,10 @@ class ProfileSettings:
     runs: int
     """Number of times each configuration should be executed."""
 
-    output_progress: bool
+    verbosity: VerbosityLevel
     """
-    Will display a progress bar on stdout during profiling
-    """
-
-    output_detailed: bool
-    """
-    Will display a progress bar, detailed output for each config along with the profiler logs
+    Controls verbosity of output. SILENT suppresses all output, INFO shows progress bar,
+    DEBUG shows progress bar plus per-config logs and profiler output.
     """
 
     derive_metric: (
@@ -596,7 +592,7 @@ class NsightProfiler:
                     raw_df,
                     func,
                     self.settings.normalize_against,
-                    self.settings.output_progress,
+                    self.settings.verbosity,
                 )
 
                 # Save to CSV if enabled
@@ -617,7 +613,7 @@ class NsightProfiler:
                         index=False,
                     )
 
-                    if self.settings.output_progress:
+                    if self.settings.verbosity >= VerbosityLevel.INFO:
                         print(
                             f"[NSIGHT-PYTHON] Refer to {raw_csv_path} for the raw profiling data"
                         )

--- a/nsight/collection/ncu.py
+++ b/nsight/collection/ncu.py
@@ -21,6 +21,7 @@ from deepdiff import DeepHash
 from nsight import exceptions, extraction, utils
 from nsight.collection import core
 from nsight.exceptions import NCUErrorContext
+from nsight.utils import VerbosityLevel
 
 
 def get_signature(
@@ -40,7 +41,7 @@ def launch_ncu(
     cache_control: Literal["none", "all"],
     clock_control: Literal["none", "base"],
     replay_mode: Literal["kernel", "range"],
-    verbose: bool,
+    verbosity: VerbosityLevel,
 ) -> str | None:
     """
     Launch NVIDIA Nsight Compute to profile the current script with specified options.
@@ -51,7 +52,7 @@ def launch_ncu(
         cache_control: Select cache control option
         clock_control: Select clock control option
         replay_mode: Select replay mode option
-        verbose: If False, log is written to a file (ncu_log.txt)
+        verbosity: Controls output verbosity level.
 
     Raises:
         NCUNotAvailableError: If NCU is not available on the system.
@@ -84,11 +85,16 @@ def launch_ncu(
     replay = f"--replay-mode {replay_mode}"
     log_path = os.path.splitext(report_path)[0] + ".log"
     log = f"--log-file {log_path}"
+
     nvtx = f'--nvtx --nvtx-include "regex:{utils.NVTX_DOMAIN}@.+/"'
     metrics_str = ",".join(metrics)
+    verbose_flag = "--verbose" if verbosity >= VerbosityLevel.DEBUG else ""
 
     # Construct the ncu command
-    ncu_command = f"""ncu {log} {cache} {clocks} {replay} {nvtx} --metrics {metrics_str} -f -o {report_path} {sys.executable} {script_path} {script_args}"""
+    ncu_command = f"""ncu {log} {cache} {clocks} {replay} {nvtx} {verbose_flag} --metrics {metrics_str} -f -o {report_path} {sys.executable} {script_path} {script_args}"""
+
+    if verbosity >= VerbosityLevel.DEBUG:
+        print(f"[NSIGHT-PYTHON] NCU command: {ncu_command}")
 
     # Check if ncu is available on the system
     ncu_available = False
@@ -113,19 +119,16 @@ def launch_ncu(
             )
 
             return log_path
-        except subprocess.CalledProcessError as e:
+        except subprocess.CalledProcessError:
             log_parser = utils.NCULogParser()
             error_logs = log_parser.get_logs(log_path, "ERROR")
-
-            # Create error context
-            error_context = NCUErrorContext(
-                errors=error_logs,
-                log_file_path=log_path,
-                metrics=metrics,
-            )
-
-            error_message = utils.format_ncu_error_message(error_context)
-            raise exceptions.ProfilerException(error_message) from None
+            raise exceptions.ProfilerException(
+                utils.format_ncu_error_message(
+                    NCUErrorContext(
+                        errors=error_logs, log_file_path=log_path, metrics=metrics
+                    )
+                )
+            ) from None
     else:
         subprocess.run([sys.executable, script_path], env=env)
         raise exceptions.NCUNotAvailableError(
@@ -230,10 +233,10 @@ class NCUCollector(core.NsightCollector):
                 self.cache_control,
                 self.clock_control,
                 self.replay_mode,
-                settings.output_detailed,
+                settings.verbosity,
             )
 
-            if settings.output_progress:
+            if settings.verbosity >= VerbosityLevel.INFO:
                 print("[NSIGHT-PYTHON] Profiling completed successfully !")
                 print(
                     f"[NSIGHT-PYTHON] Refer to {report_path} for the NVIDIA Nsight Compute CLI report"
@@ -250,7 +253,7 @@ class NCUCollector(core.NsightCollector):
                 func,
                 settings.derive_metric,
                 self.ignore_kernel_list,  # type: ignore[arg-type]
-                settings.output_progress,
+                settings.verbosity,
                 self.combine_kernel_metrics,
             )
 
@@ -264,7 +267,7 @@ class NCUCollector(core.NsightCollector):
             if get_signature(func, configs_list) != sig:
                 return None
 
-            if settings.output_progress:
+            if settings.verbosity >= VerbosityLevel.INFO:
                 utils.print_header(
                     f"Profiling {func.__name__}",
                     f"{len(configs_list)} configurations, {settings.runs} runs each",
@@ -274,8 +277,7 @@ class NCUCollector(core.NsightCollector):
                 func,
                 configs_list,
                 settings.runs,
-                settings.output_progress,
-                settings.output_detailed,
+                settings.verbosity,
                 settings.thermal_mode,
                 settings.thermal_wait,
                 settings.thermal_cont,

--- a/nsight/extraction.py
+++ b/nsight/extraction.py
@@ -11,7 +11,7 @@ Functions:
     extract_ncu_action_data(action, metrics):
         Extracts performance data for a specific kernel action from an NVIDIA Nsight Compute report.
 
-    extract_df_from_report(report_path, metrics, configs, iterations, func, derive_metric, ignore_kernel_list, output_progress, combine_kernel_metrics=None):
+    extract_df_from_report(report_path, metrics, configs, iterations, func, derive_metric, ignore_kernel_list, verbosity, combine_kernel_metrics=None):
         Processes the full NVIDIA Nsight Compute report and returns a pandas DataFrame containing performance metrics.
 """
 
@@ -27,7 +27,7 @@ import numpy as np
 import pandas as pd
 
 from nsight import exceptions, utils
-from nsight.utils import is_scalar
+from nsight.utils import VerbosityLevel, is_scalar
 
 DerivedValue: TypeAlias = float | int | None
 DerivedValueWithUnit: TypeAlias = tuple[DerivedValue, str]
@@ -84,7 +84,7 @@ def extract_df_from_report(
     func: Callable[..., Any],
     derive_metric: Callable[..., Any] | None,
     ignore_kernel_list: List[str] | None,
-    output_progress: bool,
+    verbosity: VerbosityLevel,
     combine_kernel_metrics: Callable[[float, float], float] | None = None,
 ) -> pd.DataFrame:
     """
@@ -108,13 +108,13 @@ def extract_df_from_report(
         RuntimeError: If multiple kernels are detected per config without a combining function.
         exceptions.ProfilerException: If profiling results are missing or incomplete.
     """
-    if output_progress:
+    if verbosity >= VerbosityLevel.INFO:
         print("[NSIGHT-PYTHON] Loading profiled data")
     try:
         report: ncu_report.IContext = ncu_report.load_report(report_path)
     except FileNotFoundError:
         raise exceptions.ProfilerException(
-            "No NVIDIA Nsight Compute report found. Please run nsight-python with `@nsight.analyze.kernel(output='verbose')`"
+            "No NVIDIA Nsight Compute report found. Please run nsight-python with `@nsight.analyze.kernel(verbosity=nsight.VerbosityLevel.DEBUG)`"
             "to identify the issue."
         )
 
@@ -144,7 +144,7 @@ def extract_df_from_report(
     }
 
     # Extract all profiling data
-    if output_progress:
+    if verbosity >= VerbosityLevel.INFO:
         print(f"Extracting profiling data")
     profiling_data: dict[str, list[utils.NCUActionData]] = {}
     for range_idx in range(report.num_ranges()):
@@ -171,7 +171,7 @@ def extract_df_from_report(
                 profiling_data[annotation].append(data)
 
     for annotation, annotation_data in profiling_data.items():
-        if output_progress:
+        if verbosity >= VerbosityLevel.INFO:
             print(f"Extracting {annotation} profiling data")
 
         configs_repeated = [

--- a/nsight/transformation.py
+++ b/nsight/transformation.py
@@ -15,12 +15,14 @@ from typing import Any
 import numpy as np
 import pandas as pd
 
+from nsight.utils import VerbosityLevel
+
 
 def aggregate_data(
     df: pd.DataFrame,
     func: Callable[..., Any],
     normalize_against: str | None,
-    output_progress: bool,
+    verbosity: VerbosityLevel,
 ) -> pd.DataFrame:
     """
     Groups and aggregates profiling data by configuration and annotation.
@@ -29,12 +31,12 @@ def aggregate_data(
         df: The raw profiling results.
         func: Function representing kernel configuration parameters.
         normalize_against: Name of the annotation to normalize against.
-        output_progress: Toggles the display of data processing logs
+        verbosity: Controls display of data processing logs
 
     Returns:
         Aggregated DataFrame and the (possibly normalized) metric name.
     """
-    if output_progress:
+    if verbosity >= VerbosityLevel.INFO:
         print("[NSIGHT-PYTHON] Processing profiled data")
 
     # Get the number of arguments in the signature of func (exclude *args/**kwargs)

--- a/nsight/utils.py
+++ b/nsight/utils.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import enum
 import functools
 import inspect
 import os
@@ -42,6 +43,20 @@ except ImportError:
     launch = None
 
 NVTX_DOMAIN = "nsight-python"
+
+
+class VerbosityLevel(enum.IntEnum):
+    """Verbosity level for ``@nsight.analyze.kernel``.
+
+    Selecting level N enables output at all levels with value <= N.
+    For example, ``INFO`` enables ERROR, WARNING, and INFO but not DEBUG.
+    """
+
+    SILENT = 0
+    ERROR = 1
+    WARNING = 2
+    INFO = 3
+    DEBUG = 4
 
 
 class row_panel:

--- a/tests/run_api_params.py
+++ b/tests/run_api_params.py
@@ -68,7 +68,7 @@ def resolve_all_params(
         "clock_control",
         "cache_control",
         "thermal_mode",
-        "output",
+        "verbosity",
         "output_prefix",
         "benchmark_type",
         "plot_title",
@@ -133,7 +133,12 @@ def get_app_args() -> argparse.Namespace:
         help="Enable or disable thermal control",
     )
     parser.add_argument(
-        "--output", "-o", default="progress", help="Output verbosity level"
+        "--verbosity",
+        "-o",
+        type=int,
+        default=3,
+        choices=[0, 3, 4],
+        help="Output verbosity level (0=SILENT, 3=INFO, 4=DEBUG)",
     )
     parser.add_argument(
         "--output-prefix",
@@ -199,7 +204,7 @@ def main(argv: List[str]) -> None:
         "clock_control": params["clock_control"],
         "cache_control": params["cache_control"],
         "thermal_mode": params["thermal_mode"],
-        "output": params["output"],
+        "verbosity": nsight.VerbosityLevel(params["verbosity"]),
         "output_prefix": params["output_prefix"],
     }
 

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -20,7 +20,9 @@ class DummyTestException(Exception):
 
 
 def test_annotate_context_manager_simple() -> None:
-    @nsight.analyze.kernel(configs=configs, runs=7, output="progress")
+    @nsight.analyze.kernel(
+        configs=configs, runs=7, verbosity=nsight.VerbosityLevel.INFO
+    )
     def annotate_context_manager_simple(x: int) -> None:
         a = torch.randn(64, 64, device="cuda")
         b = torch.randn(64, 64, device="cuda")
@@ -35,7 +37,9 @@ def test_annotate_decorator_simple() -> None:
     def einsum(a: torch.Tensor, b: torch.Tensor) -> Any:
         return a + b
 
-    @nsight.analyze.kernel(configs=configs, runs=7, output="quiet")
+    @nsight.analyze.kernel(
+        configs=configs, runs=7, verbosity=nsight.VerbosityLevel.SILENT
+    )
     def annotate_decorator_simple(n: int) -> None:
         a = torch.randn(64, 64, device="cuda")
         b = torch.randn(64, 64, device="cuda")
@@ -59,7 +63,9 @@ def test_annotate_decorator_simple() -> None:
     ],
 )  # type: ignore[untyped-decorator]
 def test_annotate_context_manager(ignore_failures: bool) -> None:
-    @nsight.analyze.kernel(configs=configs, runs=7, output="quiet")
+    @nsight.analyze.kernel(
+        configs=configs, runs=7, verbosity=nsight.VerbosityLevel.SILENT
+    )
     def annotate_context_manager(n: int) -> None:
         a = torch.randn(64, 64, device="cuda")
 
@@ -103,7 +109,9 @@ def test_annotate_decorator(ignore_failures: bool) -> None:
             _ = a + a
         raise DummyTestException()
 
-    @nsight.analyze.kernel(configs=configs, runs=7, output="quiet")
+    @nsight.analyze.kernel(
+        configs=configs, runs=7, verbosity=nsight.VerbosityLevel.SILENT
+    )
     def annotate_decorator(n: int) -> None:
         a = torch.randn(64, 64, device="cuda")
 
@@ -125,7 +133,9 @@ def test_annotate_decorator(ignore_failures: bool) -> None:
 def test_active_annotations_nested() -> None:
     """Test that nested annotations raise ValueError with context manager."""
 
-    @nsight.analyze.kernel(configs=[(64,)], runs=10, output="quiet")
+    @nsight.analyze.kernel(
+        configs=[(64,)], runs=10, verbosity=nsight.VerbosityLevel.SILENT
+    )
     def nested_annotation_test(n: int) -> None:
         a = torch.randn(n, n, device="cuda")
         b = torch.randn(n, n, device="cuda")
@@ -147,7 +157,9 @@ def test_active_annotations_nested() -> None:
 def test_active_annotations_duplicate_name() -> None:
     """Test that duplicate annotation names raise ValueError even when sequential."""
 
-    @nsight.analyze.kernel(configs=[(64,)], runs=10, output="quiet")
+    @nsight.analyze.kernel(
+        configs=[(64,)], runs=10, verbosity=nsight.VerbosityLevel.SILENT
+    )
     def duplicate_annotation_test(n: int) -> None:
         a = torch.randn(n, n, device="cuda")
         b = torch.randn(n, n, device="cuda")
@@ -173,7 +185,9 @@ def test_active_annotations_duplicate_name_decorator() -> None:
     def annotated_function(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
         return a + b
 
-    @nsight.analyze.kernel(configs=[(64,)], runs=10, output="quiet")
+    @nsight.analyze.kernel(
+        configs=[(64,)], runs=10, verbosity=nsight.VerbosityLevel.SILENT
+    )
     def duplicate_annotation_decorator_test(n: int) -> None:
         a = torch.randn(n, n, device="cuda")
         b = torch.randn(n, n, device="cuda")

--- a/tests/test_api_params.py
+++ b/tests/test_api_params.py
@@ -154,7 +154,7 @@ def test_config_validation_errors(scenario_name: str) -> None:
         "clock_control": "none",
         "cache_control": "all",
         "thermal_mode": "auto",
-        "output": "quiet",
+        "verbosity": nsight.VerbosityLevel.SILENT,
     }
 
     if "decorator_configs" in scenario:
@@ -208,7 +208,7 @@ def test_runtime_extraction_errors(scenario_name: str) -> None:
         "clock_control": "none",
         "cache_control": "all",
         "thermal_mode": "auto",
-        "output": "quiet",
+        "verbosity": nsight.VerbosityLevel.SILENT,
     }
 
     benchmark_type = scenario.get("benchmark_type", "default")

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 
 from nsight import collection, exceptions
+from nsight.utils import VerbosityLevel
 
 
 def func_name(x: int, y: int, z: int) -> None:
@@ -28,7 +29,7 @@ def test_launch_ncu_runs_with_ncu_available(mock_run: MagicMock) -> None:
         cache_control="all",
         clock_control="base",
         replay_mode="kernel",
-        verbose=True,
+        verbosity=VerbosityLevel.DEBUG,
     )
 
     expected_calls = [
@@ -74,7 +75,7 @@ def test_launch_ncu_falls_back_without_ncu(mock_run: MagicMock) -> None:
             cache_control="all",
             clock_control="base",
             replay_mode="kernel",
-            verbose=False,
+            verbosity=VerbosityLevel.SILENT,
         )
 
     # Verify the exception message

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -240,7 +240,7 @@ def test_no_args_vs_with_args_dataframe_comparison() -> None:
     """Compare dataframe structure for functions with and without arguments."""
 
     # Test function with no args
-    @nsight.analyze.kernel(output="quiet")
+    @nsight.analyze.kernel(verbosity=nsight.VerbosityLevel.SILENT)
     def no_args() -> None:
         a = torch.randn(64, 64, device="cuda")
         b = torch.randn(64, 64, device="cuda")
@@ -248,7 +248,9 @@ def test_no_args_vs_with_args_dataframe_comparison() -> None:
             _ = a + b
 
     # Test function with args
-    @nsight.analyze.kernel(configs=[(32,), (64,)], output="quiet")
+    @nsight.analyze.kernel(
+        configs=[(32,), (64,)], verbosity=nsight.VerbosityLevel.SILENT
+    )
     def with_args(size: int) -> None:
         a = torch.randn(size, size, device="cuda")
         b = torch.randn(size, size, device="cuda")
@@ -294,7 +296,9 @@ def test_no_args_function_with_derive_metric() -> None:
         """Convert time to arbitrary custom metric."""
         return time_ns / 1e6  # Convert to milliseconds
 
-    @nsight.analyze.kernel(runs=2, output="quiet", derive_metric=custom_metric)
+    @nsight.analyze.kernel(
+        runs=2, verbosity=nsight.VerbosityLevel.SILENT, derive_metric=custom_metric
+    )
     def no_args_with_transform() -> None:
         a = torch.randn(128, 128, device="cuda")
         b = torch.randn(128, 128, device="cuda")
@@ -449,7 +453,7 @@ configs = [(i,) for i in range(5)]
 
 
 @nsight.analyze.plot()
-@nsight.analyze.kernel(configs=configs, runs=7, output="verbose")
+@nsight.analyze.kernel(configs=configs, runs=7, verbosity=nsight.VerbosityLevel.DEBUG)
 def simple(x: int) -> None:
     a = torch.randn(64, 64, device="cuda")
     b = torch.randn(64, 64, device="cuda")
@@ -468,7 +472,7 @@ def test_simple() -> None:
 
 
 @nsight.analyze.plot()
-@nsight.analyze.kernel(configs=configs, runs=7, output="quiet")
+@nsight.analyze.kernel(configs=configs, runs=7, verbosity=nsight.VerbosityLevel.SILENT)
 def different_kernels(x: int) -> None:
     a = torch.randn(64, 64, device="cuda")
     b = torch.randn(64, 64, device="cuda")
@@ -633,7 +637,7 @@ def test_parameter_normalize_against_multiple_metrics() -> None:
 @nsight.analyze.kernel(
     configs=[(32,)],
     runs=1,
-    output="quiet",
+    verbosity=nsight.VerbosityLevel.SILENT,
     output_prefix="/tmp/test_output_prefix/test_prefix_",
 )
 def output_prefix_func(n: int) -> None:
@@ -733,7 +737,10 @@ def test_parameter_ignore_kernel_list(ignore_kernel_list: None | list[str]) -> N
     """Test the ignore_kernel_list parameter to filter out specific kernels"""
 
     @nsight.analyze.kernel(
-        configs=[(1024,)], runs=1, output="quiet", ignore_kernel_list=ignore_kernel_list
+        configs=[(1024,)],
+        runs=1,
+        verbosity=nsight.VerbosityLevel.SILENT,
+        ignore_kernel_list=ignore_kernel_list,
     )
     def ignore_kernel_func(n: int) -> None:
 
@@ -800,7 +807,7 @@ def test_parameter_clock_control(
         @nsight.analyze.kernel(
             configs=[(100, 100)],
             runs=1,
-            output="quiet",
+            verbosity=nsight.VerbosityLevel.SILENT,
             clock_control=clock_control,
         )
         def clock_control_func(x: int, y: int) -> None:
@@ -830,7 +837,7 @@ def test_parameter_cache_control(
         @nsight.analyze.kernel(
             configs=[(100, 100)],
             runs=1,
-            output="quiet",
+            verbosity=nsight.VerbosityLevel.SILENT,
             cache_control=cache_control,
         )
         def cache_control_func(x: int, y: int) -> None:
@@ -853,7 +860,7 @@ def test_parameter_thermal_mode(thermal_mode: Literal["auto", "manual", "off"]) 
     @nsight.analyze.kernel(
         configs=[(100, 100)],
         runs=1,
-        output="quiet",
+        verbosity=nsight.VerbosityLevel.SILENT,
         thermal_mode=thermal_mode,
     )
     def thermal_control_func(x: int, y: int) -> None:
@@ -890,7 +897,7 @@ def test_parameter_replay_mode(
         @nsight.analyze.kernel(
             configs=[(1024,)],
             runs=1,
-            output="quiet",
+            verbosity=nsight.VerbosityLevel.SILENT,
             replay_mode=replay_mode,
         )
         def multiple_kernels_replay_test(n: int) -> None:
@@ -1018,7 +1025,7 @@ def test_parameter_derive_metric(
     @nsight.analyze.kernel(
         configs=configs,
         runs=2,
-        output="quiet",
+        verbosity=nsight.VerbosityLevel.SILENT,
         derive_metric=derive_metric_func,
     )
     def profiled_func(x: int, y: int) -> None:
@@ -1093,37 +1100,33 @@ def test_parameter_derive_metric(
 
 
 # ============================================================================
-# output parameter test
+# verbosity parameter test
 # ============================================================================
 
 
-@pytest.mark.parametrize("output", ["quiet", "progress", "verbose", "invalid_value"])  # type: ignore[untyped-decorator]
+@pytest.mark.parametrize("verbosity", [nsight.VerbosityLevel.SILENT, nsight.VerbosityLevel.INFO, nsight.VerbosityLevel.DEBUG])  # type: ignore[untyped-decorator]
 def test_parameter_output(
     capsys: pytest.CaptureFixture,
-    output: Literal["quiet", "progress", "verbose", "invalid_value"],
+    verbosity: nsight.VerbosityLevel,
 ) -> None:
-    if output == "invalid_value":
-        with pytest.raises(
-            ValueError, match="output must be 'quiet', 'progress' or 'verbose'"
-        ):
-            nsight.analyze.kernel(output=output)(lambda x: x)  # type: ignore[call-overload]
+    @nsight.analyze.kernel(
+        configs=[(100, 100), (200, 200)], runs=2, verbosity=verbosity
+    )
+    def profiled_func(x: int, y: int) -> None:
+        _simple_kernel_impl(x, y, "test_parameter_output")
 
-    else:
+    # Run profiling
+    profile_output = profiled_func()
+    assert profile_output is not None, "ProfileResults should be returned"
 
-        @nsight.analyze.kernel(configs=[(100, 100), (200, 200)], runs=2, output=output)
-        def profiled_func(x: int, y: int) -> None:
-            _simple_kernel_impl(x, y, "test_parameter_output")
+    # Check output
+    captured = capsys.readouterr()
+    if verbosity == nsight.VerbosityLevel.SILENT:
+        assert (
+            len(captured.out) == 0
+        ), "stdout should be empty for VerbosityLevel.SILENT"
 
-        # Run profiling
-        profile_output = profiled_func()
-        assert profile_output is not None, "ProfileResults should be returned"
-
-        # Check output
-        captured = capsys.readouterr()
-        if output == "quiet":
-            assert len(captured.out) == 0, "stdout should be empty for output='quiet'"
-
-        # TODO:"progress" and "verbose" modes
+    # TODO: INFO and DEBUG modes
 
 
 # ============================================================================
@@ -1399,7 +1402,7 @@ def test_function_with_kwargs() -> None:
     match the inflated parameter count.
     """
 
-    @nsight.analyze.kernel(output="quiet")
+    @nsight.analyze.kernel(verbosity=nsight.VerbosityLevel.SILENT)
     def kernel_with_kwargs(x: int, y: int, **kwargs: Any) -> None:
         a = torch.randn(x, y, device="cuda")
         b = torch.randn(x, y, device="cuda")
@@ -1422,7 +1425,7 @@ def test_function_with_keyword_only_params() -> None:
     passed as keyword arguments for keyword-only params.
     """
 
-    @nsight.analyze.kernel(output="quiet")
+    @nsight.analyze.kernel(verbosity=nsight.VerbosityLevel.SILENT)
     def kernel_with_kw_only(x: int, *, y: int) -> None:
         a = torch.randn(x, y, device="cuda")
         b = torch.randn(x, y, device="cuda")
@@ -1440,7 +1443,7 @@ def test_function_with_keyword_only_params() -> None:
 def test_function_with_args_and_keyword_only() -> None:
     """Test that functions with *args and keyword-only params after it work."""
 
-    @nsight.analyze.kernel(output="quiet")
+    @nsight.analyze.kernel(verbosity=nsight.VerbosityLevel.SILENT)
     def kernel_mixed(x: int, *args: Any, y: int, **kwargs: Any) -> None:
         a = torch.randn(x, y, device="cuda")
         b = torch.randn(x, y, device="cuda")
@@ -1458,7 +1461,7 @@ def test_function_with_args_and_keyword_only() -> None:
 def test_default_values_omitted() -> None:
     """Test that configs can omit parameters that have default values."""
 
-    @nsight.analyze.kernel(output="quiet")
+    @nsight.analyze.kernel(verbosity=nsight.VerbosityLevel.SILENT)
     def kernel_with_defaults(x: int, y: int, z: int = 64) -> None:
         a = torch.randn(x, y, device="cuda")
         b = torch.randn(x, y, device="cuda")
@@ -1477,7 +1480,7 @@ def test_default_values_omitted() -> None:
 def test_default_values_overridden() -> None:
     """Test that configs can explicitly provide values for defaulted params."""
 
-    @nsight.analyze.kernel(output="quiet")
+    @nsight.analyze.kernel(verbosity=nsight.VerbosityLevel.SILENT)
     def kernel_with_defaults(x: int, y: int, z: int = 64) -> None:
         a = torch.randn(x, y, device="cuda")
         b = torch.randn(x, y, device="cuda")
@@ -1496,7 +1499,7 @@ def test_default_values_overridden() -> None:
 def test_keyword_only_default_omitted() -> None:
     """Test keyword-only params with defaults can be omitted from configs."""
 
-    @nsight.analyze.kernel(output="quiet")
+    @nsight.analyze.kernel(verbosity=nsight.VerbosityLevel.SILENT)
     def kernel_kw_default(x: int, *, y: int = 32) -> None:
         a = torch.randn(x, y, device="cuda")
         b = torch.randn(x, y, device="cuda")
@@ -1514,7 +1517,7 @@ def test_keyword_only_default_omitted() -> None:
 def test_too_few_config_args_rejected() -> None:
     """Test that configs with fewer args than required params are rejected."""
 
-    @nsight.analyze.kernel(output="quiet")
+    @nsight.analyze.kernel(verbosity=nsight.VerbosityLevel.SILENT)
     def kernel_two_required(x: int, y: int, z: int = 64) -> None:
         a = torch.randn(x, y, device="cuda")
         b = torch.randn(x, y, device="cuda")
@@ -1528,7 +1531,7 @@ def test_too_few_config_args_rejected() -> None:
 def test_too_many_config_args_rejected() -> None:
     """Test that configs with more args than total params are rejected."""
 
-    @nsight.analyze.kernel(output="quiet")
+    @nsight.analyze.kernel(verbosity=nsight.VerbosityLevel.SILENT)
     def kernel_two_params(x: int, y: int) -> None:
         a = torch.randn(x, y, device="cuda")
         b = torch.randn(x, y, device="cuda")
@@ -1553,7 +1556,7 @@ def test_tuple_typed_function_args() -> None:
     was silently corrupted.
     """
 
-    @nsight.analyze.kernel(output="quiet")
+    @nsight.analyze.kernel(verbosity=nsight.VerbosityLevel.SILENT)
     def kernel_with_tuple_args(
         size: int, mnkl: tuple[int, ...], tile_shape: tuple[int, ...]
     ) -> None:
@@ -1597,7 +1600,7 @@ def test_tuple_typed_function_args_multiple_metrics() -> None:
         "smsp__inst_issued.sum",
     ]
 
-    @nsight.analyze.kernel(output="quiet", metrics=metrics)
+    @nsight.analyze.kernel(verbosity=nsight.VerbosityLevel.SILENT, metrics=metrics)
     def kernel_with_tuple_args_multi(
         size: int, mnkl: tuple[int, ...], pair: tuple[int, ...]
     ) -> None:

--- a/tests/test_thermal_control.py
+++ b/tests/test_thermal_control.py
@@ -15,7 +15,7 @@ import nsight
     runs=10,
     thermal_mode="auto",
     combine_kernel_metrics=lambda x, y: x + y,
-    output="verbose",
+    verbosity=nsight.VerbosityLevel.DEBUG,
 )
 def heavy_gemm_kernel(n: int) -> None:
     """

--- a/tests/test_thermovision.py
+++ b/tests/test_thermovision.py
@@ -17,7 +17,12 @@ from nsight.thermovision import CUDA_CORE_AVAILABLE
 # ============================================================================
 
 
-@nsight.analyze.kernel(configs=[(1024,)], runs=1, thermal_mode="auto", output="quiet")
+@nsight.analyze.kernel(
+    configs=[(1024,)],
+    runs=1,
+    thermal_mode="auto",
+    verbosity=nsight.VerbosityLevel.SILENT,
+)
 def thermo_kernel(n: int) -> None:
     """Dummy Test kernel with thermovision enabled."""
     pass

--- a/tests/test_transformation.py
+++ b/tests/test_transformation.py
@@ -8,6 +8,7 @@ from typing import Any
 import pandas as pd
 
 from nsight import transformation
+from nsight.utils import VerbosityLevel
 
 
 def _one_arg(config: Any) -> None:
@@ -32,7 +33,9 @@ def test_dict_config_single_row_does_not_crash() -> None:
     # Regression: a single dict-config row used to crash groupby().agg() with
     # "unhashable type: 'dict'". The output must keep the dict as a real dict.
     dims = {"M": 512, "K": 512, "N": 512}
-    result = transformation.aggregate_data(_raw_df([dims]), _one_arg, None, False)
+    result = transformation.aggregate_data(
+        _raw_df([dims]), _one_arg, None, VerbosityLevel.SILENT
+    )
     assert len(result) == 1
     assert result["config"].iloc[0] == dims
     assert isinstance(result["config"].iloc[0], dict)
@@ -48,7 +51,7 @@ def test_dict_config_independent_of_run_count() -> None:
     dims = {"M": 256, "K": 256, "N": 256}
     for runs in (1, 2, 5):
         result = transformation.aggregate_data(
-            _raw_df([dims] * runs), _one_arg, None, False
+            _raw_df([dims] * runs), _one_arg, None, VerbosityLevel.SILENT
         )
         assert len(result) == 1
         assert result["NumRuns"].iloc[0] == runs
@@ -59,7 +62,9 @@ def test_distinct_dict_configs_stay_distinct() -> None:
     # Different dicts form different groups, each preserved as a real dict.
     d1 = {"M": 512, "K": 512, "N": 512}
     d2 = {"M": 1024, "K": 1024, "N": 1024}
-    result = transformation.aggregate_data(_raw_df([d1, d2]), _one_arg, None, False)
+    result = transformation.aggregate_data(
+        _raw_df([d1, d2]), _one_arg, None, VerbosityLevel.SILENT
+    )
     assert len(result) == 2
     configs = list(result["config"])
     assert all(isinstance(c, dict) for c in configs)
@@ -69,7 +74,9 @@ def test_distinct_dict_configs_stay_distinct() -> None:
 def test_list_config_single_row_does_not_crash() -> None:
     # Lists are unhashable too, and must also be preserved as lists.
     shape = [512, 512]
-    result = transformation.aggregate_data(_raw_df([shape]), _one_arg, None, False)
+    result = transformation.aggregate_data(
+        _raw_df([shape]), _one_arg, None, VerbosityLevel.SILENT
+    )
     assert len(result) == 1
     assert result["config"].iloc[0] == shape
     assert isinstance(result["config"].iloc[0], list)
@@ -77,6 +84,8 @@ def test_list_config_single_row_does_not_crash() -> None:
 
 def test_numeric_config_keeps_native_dtype() -> None:
     # Sortable, hashable configs must not be needlessly coerced to strings.
-    result = transformation.aggregate_data(_raw_df([128]), _one_arg, None, False)
+    result = transformation.aggregate_data(
+        _raw_df([128]), _one_arg, None, VerbosityLevel.SILENT
+    )
     assert result["config"].iloc[0] == 128
     assert pd.api.types.is_integer_dtype(result["config"])


### PR DESCRIPTION
This PR drops the output parameter and introduces the verbosity parameter:


verbosity takes nsight.VerbosityLevel as the input:


- ``VerbosityLevel.SILENT``: Suppresses all output. NCU logs are disabled,
              which reduces detail in ``ProfilerException`` messages if the NCU run fails.
- ``VerbosityLevel.ERROR``: Enables NCU log file capture; errors from NCU are
              included in ``ProfilerException`` on failure.
- ``VerbosityLevel.INFO``: Shows a progress bar, profiling completion messages,
              and report file paths.
- ``VerbosityLevel.DEBUG``: Adds configuration-specific logs, the full NCU CLI
              command, and enables NCU verbose output.