### PR TITLE
add reference to Nsight Compute section on clock control

### DIFF
--- a/nsight/analyze.py
+++ b/nsight/analyze.py
@@ -174,6 +174,8 @@ def kernel(
             - ``"none"``: No GPC or memory frequencies are changed during profiling.
 
             Default: ``"none"``
+
+            Refer the `Nsight Compute documentation on Clock Control <https://docs.nvidia.com/nsight-compute/ProfilingGuide/index.html#clock-control>`_ for more details.
         cache_control: Control the behavior of the GPU caches during profiling. Allowed values:
 
             - ``"all"``: All GPU caches are flushed before each kernel replay iteration during profiling. While metric values in the execution environment of the application might be slightly different without invalidating the caches, this mode offers the most reproducible metric results across the replay passes and also across multiple runs of the target application.

--- a/nsight/analyze.py
+++ b/nsight/analyze.py
@@ -175,7 +175,7 @@ def kernel(
 
             Default: ``"none"``
 
-            Refer the `Nsight Compute documentation on Clock Control <https://docs.nvidia.com/nsight-compute/ProfilingGuide/index.html#clock-control>`_ for more details.
+            Refer the `NVIDIA Nsight Compute documentation on Clock Control <https://docs.nvidia.com/nsight-compute/ProfilingGuide/index.html#clock-control>`_ for more details.
         cache_control: Control the behavior of the GPU caches during profiling. Allowed values:
 
             - ``"all"``: All GPU caches are flushed before each kernel replay iteration during profiling. While metric values in the execution environment of the application might be slightly different without invalidating the caches, this mode offers the most reproducible metric results across the replay passes and also across multiple runs of the target application.


### PR DESCRIPTION
Minor update to the documentation for the clock_control parameter for the API nsight.analyze.kernel 