### PR TITLE
Add multithreading support via NVTX start/end ranges

### DIFF
--- a/nsight/annotation.py
+++ b/nsight/annotation.py
@@ -88,7 +88,7 @@ def is_active_annotation(name: str) -> bool:
     return False
 
 
-class annotate(nvtx.annotate):  # type: ignore[misc]
+class annotate:
     """
     A decorator/context-manager hybrid for marking profiling regions.
     The encapsulated code will be profiled and associated with an NVTX
@@ -129,10 +129,10 @@ class annotate(nvtx.annotate):  # type: ignore[misc]
         Nested annotations are currently not supported. However, since each
         annotation is expected to contain a single kernel launch by default,
         nested annotations should not be necessary in typical usage scenarios.
-        Entering and exiting the annotation context pushes and pops an NVTX
-        range, so calling ``nvtx.pop_range()`` inside the annotation context
-        without a corresponding push would pop the annotation context's own
-        range instead, resulting in incorrect profiling results.
+        Entering and exiting the annotation context starts and ends an NVTX
+        range that is visible across all threads in the profiled process, so
+        kernels launched from worker threads within the annotated region are
+        also captured.
 
     """
 
@@ -144,9 +144,7 @@ class annotate(nvtx.annotate):  # type: ignore[misc]
         if ignore_failures and not utils.CUDA_CORE_AVAILABLE:
             raise ImportError(CUDA_CORE_UNAVAILABLE_MSG)
 
-        super().__init__(name, domain=utils.NVTX_DOMAIN)
-
-    def __enter__(self) -> nvtx.annotate:
+    def __enter__(self) -> "annotate":
 
         # Check for nested annotations
         if _is_in_annotation():
@@ -164,14 +162,15 @@ class annotate(nvtx.annotate):  # type: ignore[misc]
 
         add_active_annotation(self.name)
         _set_in_annotation(True)
-        return super().__enter__()
+        self._range_id = nvtx.start_range(message=self.name, domain=utils.NVTX_DOMAIN)
+        return self
 
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> bool:
         try:
             if exc_type and self.ignore_failures:
                 utils.launch_dummy_kernel_module()
         finally:
-            super().__exit__(exc_type, exc_value, traceback)
+            nvtx.end_range(self._range_id)
             _set_in_annotation(False)
 
         if exc_type and not self.ignore_failures:

--- a/nsight/collection/ncu.py
+++ b/nsight/collection/ncu.py
@@ -229,7 +229,7 @@ def launch_ncu(
         "--process-id",
         str(target_pid),
         "--nvtx-include",
-        f"regex:{utils.NVTX_DOMAIN}@.+/",
+        f"regex:{utils.NVTX_DOMAIN}@.+",
         "--log-file",
         log_path,
         "--cache-control",

--- a/nsight/extraction.py
+++ b/nsight/extraction.py
@@ -161,7 +161,7 @@ def extract_df_from_report(
                 if ignore_kernel_list and action.name() in ignore_kernel_list:
                     continue
 
-                annotation: str = domain.push_pop_ranges()[0]
+                annotation: str = domain.start_end_ranges()[0]
                 data = extract_ncu_action_data(action, metrics)
 
                 if annotation not in profiling_data:

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import threading
 from typing import Any
 
 import pytest
@@ -123,6 +124,33 @@ def test_annotate_decorator(ignore_failures: bool) -> None:
             raise_exception(a, False)
 
     annotate_decorator()
+
+
+def test_annotate_captures_kernel_from_worker_thread() -> None:
+    """Test that kernels launched from a worker thread within an annotation are captured."""
+
+    @nsight.analyze.kernel(
+        configs=[(64,)], runs=7, verbosity=nsight.VerbosityLevel.SILENT
+    )
+    def annotate_worker_thread(n: int) -> None:
+        a = torch.randn(n, n, device="cuda")
+        b = torch.randn(n, n, device="cuda")
+
+        def launch_kernel() -> None:
+            _ = a + b
+            torch.cuda.synchronize()
+
+        with nsight.annotate("worker_thread"):
+            worker = threading.Thread(target=launch_kernel)
+            worker.start()
+            worker.join()
+
+    result = annotate_worker_thread()
+    df = result.to_dataframe()
+
+    # The kernel launched from the worker thread must appear in the results;
+    # if it were not captured, extraction would have raised instead.
+    assert "worker_thread" in df["Annotation"].values
 
 
 # ============================================================================

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -38,7 +38,7 @@ def test_launch_ncu_runs_with_ncu_available(mock_popen: MagicMock) -> None:
         "--process-id",
         str(target_pid),
         "--nvtx-include",
-        "regex:nsight-python@.+/",
+        "regex:nsight-python@.+",
         "--log-file",
         "report.log",
         "--cache-control",


### PR DESCRIPTION
`nsight.annotate` NVTX push/pop ranges are scoped per thread by default, so kernels launched from any thread other than the one that entered the annotation (e.g. PyTorch autograd's backward-pass worker threads) are invisible to ncu's `--nvtx-include` filter, producing no report. Switch to using NVTX start/end range instead, making the ranges visible across all threads in the profiled process.