### PR TITLE
CI - add Windows A100 runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,6 +66,9 @@ jobs:
     runs-on: windows-amd64-gpu-a100-latest-1
     steps:
       - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
       - name: "Install NCU 2026.2.1.0 (CUDA 13.3 Update 1)"
         shell: pwsh
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
           pip install hatch
           hatch run docs:build
 
-  test:
+  test-linux:
     name: test (${{ matrix.platform.runner }})
     runs-on: ${{ matrix.platform.runner }}
     strategy:
@@ -44,30 +44,37 @@ jobs:
             ncu_installer_url: "https://developer.nvidia.com/downloads/assets/tools/secure/nsight-compute/2026_2_1/nsight_compute-linux-x86_64-2026.2.1.6.run"
           - runner: linux-arm64-gpu-l4-latest-1
             ncu_installer_url: "https://developer.nvidia.com/downloads/assets/tools/secure/nsight-compute/2026_2_1/nsight_compute-linux-sbsa-2026.2.1.6.run"
-          - runner: windows-amd64-gpu-a100-latest-1
-            ncu_installer_url: "https://developer.nvidia.com/downloads/assets/tools/secure/nsight-compute/2026_2_1/nsight_compute-windows-x86_64-2026.2.1.6.msi"
     container:
       image: nvcr.io/nvidia/pytorch:26.06-py3
       options: "--cap-add=SYS_ADMIN --gpus all"
     steps:
       - uses: actions/checkout@v5
       - name: "Install NCU 2026.2.1.0 (CUDA 13.3 Update 1)"
-        if: runner.os == 'Linux'
         run: |
           curl -L -o ncu_installer.run "${{ matrix.platform.ncu_installer_url }}"
           chmod +x ncu_installer.run
           ./ncu_installer.run -- -noprompt
           rm ncu_installer.run
           echo "/usr/local/NVIDIA-Nsight-Compute-2026.2" >> $GITHUB_PATH
+      - name: "Running Tests"
+        run: |
+          pip install hatch
+          hatch run test_cu13:run
+
+  test-windows:
+    name: test (windows-amd64-gpu-a100-latest-1)
+    runs-on: windows-amd64-gpu-a100-latest-1
+    steps:
+      - uses: actions/checkout@v5
       - name: "Install NCU 2026.2.1.0 (CUDA 13.3 Update 1)"
-        if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          curl.exe -L -o ncu_installer.msi "${{ matrix.platform.ncu_installer_url }}"
+          curl.exe -L -o ncu_installer.msi "https://developer.nvidia.com/downloads/assets/tools/secure/nsight-compute/2026_2_1/nsight_compute-windows-x86_64-2026.2.1.6.msi"
           Start-Process msiexec.exe -Wait -ArgumentList '/i ncu_installer.msi /quiet /norestart'
           Remove-Item ncu_installer.msi
           "C:\Program Files\NVIDIA Corporation\Nsight Compute 2026.2.1" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: "Running Tests"
+        shell: pwsh
         run: |
           pip install hatch
           hatch run test_cu13:run

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,18 +44,29 @@ jobs:
             ncu_installer_url: "https://developer.nvidia.com/downloads/assets/tools/secure/nsight-compute/2026_2_1/nsight_compute-linux-x86_64-2026.2.1.6.run"
           - runner: linux-arm64-gpu-l4-latest-1
             ncu_installer_url: "https://developer.nvidia.com/downloads/assets/tools/secure/nsight-compute/2026_2_1/nsight_compute-linux-sbsa-2026.2.1.6.run"
+          - runner: windows-amd64-gpu-a100-latest-1
+            ncu_installer_url: "https://developer.nvidia.com/downloads/assets/tools/secure/nsight-compute/2026_2_1/nsight_compute-windows-x86_64-2026.2.1.6.msi"
     container:
       image: nvcr.io/nvidia/pytorch:26.06-py3
       options: "--cap-add=SYS_ADMIN --gpus all"
     steps:
       - uses: actions/checkout@v5
       - name: "Install NCU 2026.2.1.0 (CUDA 13.3 Update 1)"
+        if: runner.os == 'Linux'
         run: |
           curl -L -o ncu_installer.run "${{ matrix.platform.ncu_installer_url }}"
           chmod +x ncu_installer.run
           ./ncu_installer.run -- -noprompt
           rm ncu_installer.run
           echo "/usr/local/NVIDIA-Nsight-Compute-2026.2" >> $GITHUB_PATH
+      - name: "Install NCU 2026.2.1.0 (CUDA 13.3 Update 1)"
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          curl.exe -L -o ncu_installer.msi "${{ matrix.platform.ncu_installer_url }}"
+          Start-Process msiexec.exe -Wait -ArgumentList '/i ncu_installer.msi /quiet /norestart'
+          Remove-Item ncu_installer.msi
+          "C:\Program Files\NVIDIA Corporation\Nsight Compute 2026.2.1" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: "Running Tests"
         run: |
           pip install hatch

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,6 +73,10 @@ jobs:
           Start-Process msiexec.exe -Wait -ArgumentList '/i ncu_installer.msi /quiet /norestart'
           Remove-Item ncu_installer.msi
           "C:\Program Files\NVIDIA Corporation\Nsight Compute 2026.2.1" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: "Install PyTorch (CUDA 13.2)"
+        shell: pwsh
+        run: |
+          pip3 install torch --index-url https://download.pytorch.org/whl/cu132
       - name: "Running Tests"
         shell: pwsh
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,7 +76,7 @@ jobs:
       - name: "Install PyTorch (CUDA 13.2)"
         shell: pwsh
         run: |
-          pip3 install torch --index-url https://download.pytorch.org/whl/cu132
+          pip install torch --index-url https://download.pytorch.org/whl/cu132
       - name: "Running Tests"
         shell: pwsh
         run: |


### PR DESCRIPTION
Add a Windows A100 runner to CI, splitting the test job into test-linux and test-windows.

The Windows job installs Nsight Compute 13.3 update 1,  the MSVC redistributable (torch's DLLs need it on a
fresh image) on the runner. 

It also setups `hatch` and installs test dependencies `torch` and `cuda-tile` test into the `test_cu13`  hatch env. 

Tests run with `MPLBACKEND=Agg`, since matplotlib defaults to TkAgg on Windows and tkinter is not
properly configured on the runner.