### PR TITLE
Handle tensor configuration values in aggregation

### DIFF
--- a/nsight/transformation.py
+++ b/nsight/transformation.py
@@ -97,16 +97,16 @@ def aggregate_data(
                 )(col),
             )
 
-    # Group keys must be hashable (pandas factorizes them) and sortable
-    # (groupby sorts them). Keys that are neither — e.g. dict- or list-valued
-    # config parameters — are grouped on a temporary stringified key, and the
-    # original objects are recovered with a "first" aggregation so the output
-    # preserves them (a dict stays a dict instead of becoming its repr).
-    def _is_groupable(series: pd.Series) -> bool:
+    # Group keys must be hashable because pandas factorizes them. Sorting is
+    # disabled below because valid hashable objects, such as multi-element
+    # tensors, may not define a scalar ordering. Unhashable keys, such as dict-
+    # or list-valued config parameters, are grouped on a temporary stringified
+    # key. The original objects are recovered with a "first" aggregation so the
+    # output preserves them (a dict stays a dict instead of becoming its repr).
+    def _is_hashable(series: pd.Series) -> bool:
         non_null = series.dropna()
         try:
             set(non_null)
-            sorted(non_null)
         except (TypeError, ValueError):
             return False
         return True
@@ -115,7 +115,7 @@ def aggregate_data(
     group_keys: list[str] = []
     func_field_keys: list[str] = []
     for col in groupby_columns + func_fields:
-        if _is_groupable(df[col]):
+        if _is_hashable(df[col]):
             key = col
         else:
             key = f"{col}__sortkey__"
@@ -131,7 +131,7 @@ def aggregate_data(
     df["Value"] = pd.to_numeric(df["Value"])
 
     # Apply aggregation with named aggregation
-    groupby_df = df.groupby(group_keys, dropna=False)
+    groupby_df = df.groupby(group_keys, dropna=False, sort=False)
     agg_df = groupby_df.agg(**named_aggs).reset_index()
 
     # Compute 95% confidence intervals

--- a/tests/test_transformation.py
+++ b/tests/test_transformation.py
@@ -6,6 +6,7 @@
 from typing import Any
 
 import pandas as pd
+import torch
 
 from nsight import transformation
 from nsight.utils import VerbosityLevel
@@ -89,3 +90,30 @@ def test_numeric_config_keeps_native_dtype() -> None:
     )
     assert result["config"].iloc[0] == 128
     assert pd.api.types.is_integer_dtype(result["config"])
+
+
+def test_multi_element_tensor_config_does_not_crash() -> None:
+    # Multi-element tensor comparisons do not produce a scalar boolean, so
+    # pandas must group them without sorting the configuration values.
+    config = torch.arange(4).reshape(2, 2)
+    result = transformation.aggregate_data(
+        _raw_df([config, config]), _one_arg, None, VerbosityLevel.SILENT
+    )
+    assert len(result) == 1
+    assert result["config"].iloc[0] is config
+    assert result["NumRuns"].iloc[0] == 2
+
+
+def test_distinct_multi_element_tensor_configs_stay_distinct() -> None:
+    config1 = torch.zeros((2, 2))
+    config2 = torch.ones((2, 2))
+    result = transformation.aggregate_data(
+        _raw_df([config1, config1, config2, config2]),
+        _one_arg,
+        None,
+        VerbosityLevel.SILENT,
+    )
+    assert len(result) == 2
+    assert result["config"].iloc[0] is config1
+    assert result["config"].iloc[1] is config2
+    assert result["NumRuns"].tolist() == [2, 2]


### PR DESCRIPTION
Avoid sorting hashable configuration values during pandas grouping. Add regression coverage for repeated and distinct multi-element tensors.