### PR TITLE
Add Custom Info Collectors Feature

### DIFF
--- a/docs/source/analyze.rst
+++ b/docs/source/analyze.rst
@@ -44,3 +44,20 @@ nsight.analyze
 .. autoclass:: nsight.analyze.plot
 
 .. autoclass:: nsight.analyze.ignore_failures
+
+Experimental information collectors
+-----------------------------------
+
+Custom information collectors add application-specific columns to profiling
+results. The API is experimental and may change without a compatibility
+guarantee. Use the ``scope`` parameter to select whether a collector runs once
+per profiling session, once per configuration, once per repeated run, or once
+per annotation.
+
+.. autofunction:: nsight.experimental.collect
+
+.. autoclass:: nsight.CollectionScope
+   :no-undoc-members:
+
+.. autoclass:: nsight.InfoCollector
+   :no-undoc-members:

--- a/docs/source/release_notes/topics/updates-in-nsight-python-1.0.0.rst
+++ b/docs/source/release_notes/topics/updates-in-nsight-python-1.0.0.rst
@@ -7,6 +7,14 @@ Updates in Nsight Python 1.0.0
 Enhancements
 ------------
 
+- **Added experimental custom information collectors**: Profiling results can
+  now include application-specific information collected once per session,
+  once per configuration, once per repeated run, or once per annotation. Use
+  :func:`nsight.experimental.collect` with a
+  :class:`~nsight.info_collector.CollectionScope` and pass the decorated
+  functions through the ``info_collectors`` parameter of
+  :func:`@nsight.analyze.kernel <nsight.analyze.kernel>`.
+
 - **Eliminated per-decorator Python script relaunch**: Previously, nsight-python
   relaunched the entire Python script once for each :func:`@nsight.analyze.kernel <nsight.analyze.kernel>` decorated
   function in order to collect profiles using NVIDIA Nsight Compute. nsight-python now

--- a/examples/13_custom_info_collectors.py
+++ b/examples/13_custom_info_collectors.py
@@ -1,0 +1,254 @@
+# Copyright 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Example 13: Custom Info Collectors
+==================================
+
+This example demonstrates how to use custom information collectors
+to add additional columns to your profiling data using the decorator-based API.
+
+New concepts:
+- Using `@nsight.experimental.collect(scope=...)`
+- Collecting information once, per configuration, per run, or per annotation
+- Understanding collection scopes and aggregation behavior
+"""
+
+import subprocess
+import time
+from typing import Any
+
+import torch
+from cuda.core import system
+
+import nsight
+
+
+# Define custom collectors for "once" scope (collected once at start)
+@nsight.experimental.collect(scope=nsight.CollectionScope.ONCE)
+def driver_version() -> str:
+    """Get the CUDA user-mode driver version."""
+    try:
+        return ".".join(str(part) for part in system.get_user_mode_driver_version())
+    except Exception:
+        return "unknown"
+
+
+@nsight.experimental.collect(scope=nsight.CollectionScope.ONCE)
+def cuda_version() -> str:
+    """Get CUDA version from nvcc."""
+    try:
+        result = subprocess.run(
+            ["nvcc", "--version"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        # Parse output like: "Cuda compilation tools, release 12.9, V12.9.41"
+        for line in result.stdout.split("\n"):
+            if "release" in line and "V" in line:
+                # Extract version after "V"
+                version_part = line.split("V")[1].strip()
+                # Take everything before first space/newline
+                version = version_part.split()[0]
+                return version
+        return "unknown"
+    except Exception:
+        return "unknown"
+
+
+# Define custom collectors for "run" scope (collected for every repeated run)
+@nsight.experimental.collect(scope=nsight.CollectionScope.RUN)
+def gpu_temp_c(*config_args: Any) -> int | None:  # pylint: disable=unused-argument
+    """Get GPU temperature for the current configuration."""
+    try:
+        result = subprocess.run(
+            ["nvidia-smi", "--query-gpu=temperature.gpu", "--format=csv,noheader"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return int(result.stdout.strip().split("\n")[0])
+    except Exception:
+        return None
+
+
+@nsight.experimental.collect(scope=nsight.CollectionScope.RUN)
+def run_timestamp(*config_args: Any) -> str:  # pylint: disable=unused-argument
+    """Get timestamp when each configuration run starts (formatted as HH:MM:SS)."""
+    return time.strftime("%H:%M:%S", time.localtime())
+
+
+# CONFIG collectors are evaluated once for each distinct configuration.
+@nsight.experimental.collect(scope=nsight.CollectionScope.CONFIG)
+def matrix_elements(*config_args: Any) -> int | None:
+    """
+    Example of a config-dependent collector.
+    This demonstrates how you can compute derived values based on config parameters.
+    """
+    # config_args will contain (n, dtype) in this case
+    if len(config_args) > 0:
+        n: int = config_args[0]
+        return n * n  # Total matrix elements
+    return None
+
+
+# Define custom collectors for "annotation" scope (collected for each annotation)
+# Counter state for execution order tracking
+_annotation_counter = {"count": 0}
+
+
+@nsight.experimental.collect(scope=nsight.CollectionScope.ANNOTATION)
+def exec_order(
+    annotation_name: str, *config_args: Any
+) -> int:  # pylint: disable=unused-argument
+    """
+    Counter that tracks the execution order of annotations.
+    Increments with each annotation call to show execution sequence.
+    """
+    _annotation_counter["count"] += 1
+    return _annotation_counter["count"]
+
+
+@nsight.experimental.collect(scope=nsight.CollectionScope.ANNOTATION)
+def power_draw_w(
+    annotation_name: str, *config_args: Any
+) -> float | None:  # pylint: disable=unused-argument
+    """Get GPU power draw at the start of each annotation."""
+    try:
+        result = subprocess.run(
+            ["nvidia-smi", "--query-gpu=power.draw", "--format=csv,noheader"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        # Parse "123.45 W" -> 123.45
+        power_str = result.stdout.strip().split("\n")[0].replace(" W", "")
+        return float(power_str)
+    except Exception:
+        return None
+
+
+@nsight.experimental.collect(scope=nsight.CollectionScope.ANNOTATION)
+def ann_info(annotation_name: str, *config_args: Any) -> str:
+    """
+    Example showing how to use both annotation name and config in a collector.
+    """
+    n = config_args[0] if config_args else 0
+    return f"{annotation_name}_n{n}"
+
+
+@nsight.analyze.plot("13_custom_info_collectors.png", print_data=True, plot_type="bar")
+@nsight.analyze.kernel(
+    runs=10,
+    output_csv=True,
+    verbosity=nsight.VerbosityLevel.DEBUG,
+    info_collectors=[
+        # "once" scope: collected once at the start of profiling
+        driver_version,  # Column name: driver_version
+        cuda_version,  # Column name: cuda_version
+        # "run" scope: collected for every repeated run
+        gpu_temp_c,  # Column name: gpu_temp_c
+        run_timestamp,  # Column name: run_timestamp
+        # "config" scope: collected once for each configuration
+        matrix_elements,  # Column name: matrix_elements
+        # "annotation" scope: collected for each annotation
+        exec_order,  # Column name: exec_order
+        power_draw_w,  # Column name: power_draw_w
+        ann_info,  # Column name: ann_info
+    ],
+)
+def benchmark_with_custom_info(n: int, dtype: torch.dtype) -> None:
+    """
+    Matrix multiplication benchmark with custom info collection.
+
+    The resulting DataFrame will include:
+    - Standard columns: Annotation, Value, Metric, Kernel, GPU, Host, etc.
+    - Config parameters: n, dtype
+    - Custom "once" columns: driver_version, cuda_version
+    - Custom "run" columns: gpu_temp_c_Avg/Std/Min/Max, run_timestamp
+    - Custom "config" columns: matrix_elements_Avg/Std/Min/Max
+    - Custom "annotation" columns: exec_order_Avg/Std/Min/Max, power_draw_w_Avg/Std/Min/Max, ann_info
+    """
+    a = torch.randn(n, n, device="cuda", dtype=dtype)
+    b = torch.randn(n, n, device="cuda", dtype=dtype)
+
+    with nsight.annotate("matmul"):
+        _ = a @ b
+
+    # Add another annotation to demonstrate annotation-scope collectors
+    with nsight.annotate("add"):
+        _ = a + b
+        # Small delay to allow temperature/power to stabilize
+        time.sleep(0.1)
+
+
+def main() -> None:
+    """Run the benchmark with multiple configurations."""
+    configs = [
+        (512, torch.float32),
+        (1024, torch.float32),
+        (2048, torch.float32),
+        (1024, torch.float16),
+        (2048, torch.float16),
+    ]
+
+    results = benchmark_with_custom_info(configs=configs)
+
+    print("\n" + "=" * 80)
+    print("Custom Info Collectors Example Complete!")
+    print("=" * 80)
+    print("\nThe DataFrame now includes custom columns:")
+    print("\n  ONCE scope (constant across all runs):")
+    print("    - driver_version")
+    print("    - cuda_version")
+    print("\n  CONFIG scope (collected once per configuration):")
+    print("    - matrix_elements_Avg/Std/Min/Max (numeric)")
+    print("\n  RUN scope (vary per repeated run, aggregated):")
+    print("    - gpu_temp_c_Avg/Std/Min/Max (numeric)")
+    print("    - run_timestamp (string, first value taken)")
+    print("\n  ANNOTATION scope (vary per annotation):")
+    print("    - exec_order_Avg/Std/Min/Max (numeric, shows execution order)")
+    print("    - power_draw_w_Avg/Std/Min/Max (numeric, aggregated)")
+    print("    - ann_info (string, first value taken)")
+    print("\nNote: Run and annotation-scope collectors can vary across runs.")
+    print("      Numeric collectors are aggregated (mean, std, min, max) like Value.")
+    print("      Non-numeric collectors are kept as-is (first value taken).")
+    print("\nCheck the printed DataFrame above to see all columns!")
+
+    if results is not None:
+        # Demonstrate accessing custom columns from all four scopes
+        df = results.to_dataframe()
+
+        # Show ONCE scope data (constant across all rows)
+        print("\n" + "=" * 80)
+        print("ONCE scope collectors (constant values):")
+        print("=" * 80)
+        if "driver_version" in df.columns:
+            print(f"  Driver Version: {df['driver_version'].iloc[0]}")
+        if "cuda_version" in df.columns:
+            print(f"  CUDA Version:   {df['cuda_version'].iloc[0]}")
+
+        # Show CONFIG and ANNOTATION scope data (varies, so aggregated)
+        print("\n" + "=" * 80)
+        print("CONFIG and ANNOTATION scope collectors (aggregated per run):")
+        print("=" * 80)
+
+        # Select columns to display
+        display_cols = ["Annotation", "n", "dtype"]
+        if "gpu_temp_c_Avg" in df.columns:
+            display_cols.append("gpu_temp_c_Avg")
+        if "run_timestamp" in df.columns:
+            display_cols.append("run_timestamp")
+        if "exec_order_Min" in df.columns:
+            display_cols.append("exec_order_Min")
+        if "power_draw_w_Max" in df.columns:
+            display_cols.append("power_draw_w_Max")
+        if "ann_info" in df.columns:
+            display_cols.append("ann_info")
+
+        print(df[display_cols].to_string(index=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/README.md
+++ b/examples/README.md
@@ -116,3 +116,9 @@ This will profile a simple matrix multiplication and generate a plot showing the
 
 - **`12_cutile.py`** - Profiling a cuTile kernel
   - Comparing against PyTorch kernel for different problem sizes
+
+- **`13_custom_info_collectors.py`** - Custom information collectors
+  - Using `@nsight.experimental.collect(scope=...)`
+  - Collecting information once, per configuration, per run, or per annotation
+  - Understanding collection scopes and aggregation behavior
+  - Tracking execution order and system state during profiling

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -70,3 +70,10 @@ def test_11_output_csv() -> None:
 def test_12_cutile() -> None:
     cutile = importlib.import_module("examples.12_cutile")
     cutile.main()
+
+
+def test_13_custom_info_collectors() -> None:
+    custom_info_collectors = importlib.import_module(
+        "examples.13_custom_info_collectors"
+    )
+    custom_info_collectors.main()

--- a/nsight/__init__.py
+++ b/nsight/__init__.py
@@ -3,9 +3,10 @@
 
 from importlib.metadata import version
 
-from nsight import analyze
+from nsight import analyze, experimental
 from nsight.annotation import annotate
 from nsight.collection.ncu import try_init_injection
+from nsight.info_collector import CollectionScope, InfoCollector
 from nsight.utils import VerbosityLevel, col_panel, row_panel
 
 # Load injection library and symbols for NCU attach (if available)
@@ -13,4 +14,11 @@ try_init_injection()
 
 __version__ = version("nsight-python")
 
-__all__ = ["analyze", "annotate", "VerbosityLevel"]
+__all__ = [
+    "CollectionScope",
+    "InfoCollector",
+    "VerbosityLevel",
+    "analyze",
+    "annotate",
+    "experimental",
+]

--- a/nsight/analyze.py
+++ b/nsight/analyze.py
@@ -16,6 +16,7 @@ from numpy.typing import NDArray
 
 import nsight.collection as collection
 import nsight.visualization as visualization
+from nsight.info_collector import CollectionScope, InfoCollector
 from nsight.utils import VerbosityLevel
 
 
@@ -54,6 +55,14 @@ def kernel(
     combine_kernel_metrics: Callable[[float, float], float] | None = None,
     output_prefix: str | None = None,
     output_csv: bool = False,
+    info_collectors: (
+        Sequence[
+            InfoCollector
+            | tuple[str, Callable[..., Any], str | CollectionScope]
+            | Callable[..., Any]
+        ]
+        | None
+    ) = None,
 ) -> Callable[[Callable[..., None]], Callable[..., collection.core.ProfileResults]]: ...
 
 
@@ -84,6 +93,14 @@ def kernel(
     combine_kernel_metrics: Callable[[float, float], float] | None = None,
     output_prefix: str | None = None,
     output_csv: bool = False,
+    info_collectors: (
+        Sequence[
+            InfoCollector
+            | tuple[str, Callable[..., Any], str | CollectionScope]
+            | Callable[..., Any]
+        ]
+        | None
+    ) = None,
 ) -> (
     Callable[..., collection.core.ProfileResults]
     | Callable[[Callable[..., None]], Callable[..., collection.core.ProfileResults]]
@@ -299,6 +316,50 @@ def kernel(
                 - ``Host``: Host machine name
                 - ``ComputeClock``: GPU compute clock frequency
                 - ``MemoryClock``: GPU memory clock frequency
+        info_collectors: Optional list of custom information collectors.
+            Collectors should be functions decorated with
+            ``@nsight.experimental.collect(scope=...)``.
+            The function name will be used as the column name in the DataFrame.
+
+            **Decorated functions** (recommended)::
+
+                @nsight.experimental.collect(scope=nsight.CollectionScope.ONCE)
+                def driver_version():
+                    from cuda.core import system
+                    return ".".join(
+                        str(part) for part in system.get_user_mode_driver_version()
+                    )
+
+                @nsight.experimental.collect(scope=nsight.CollectionScope.CONFIG)
+                def matrix_elements(n, dtype):
+                    return n * n
+
+                @nsight.experimental.collect(scope=nsight.CollectionScope.RUN)
+                def gpu_temp_c(n, dtype):
+                    return get_gpu_temperature()
+
+                @nsight.experimental.collect(
+                    scope=nsight.CollectionScope.ANNOTATION
+                )
+                def ann_timestamp(annotation_name, *config_args):
+                    return time.time()
+
+                @nsight.analyze.kernel(
+                    info_collectors=[
+                        driver_version, matrix_elements, gpu_temp_c, ann_timestamp
+                    ]
+                )
+                def my_benchmark(n, dtype):
+                    ...
+
+            Collectors may also be supplied as ``(name, callback, scope)``
+            tuples, where ``scope`` is ``"once"``, ``"config"``, ``"run"``,
+            or ``"annotation"`` (or a :class:`nsight.CollectionScope`).
+
+            Column naming: ``once``-scope and non-numeric collectors produce a
+            single column named after the function. Numeric ``config``/``run``/
+            ``annotation``-scope collectors are aggregated across runs into four
+            columns ``<name>_Avg``, ``<name>_Std``, ``<name>_Min``, ``<name>_Max``.
     """
     # Strip whitespace
     metrics = [m.strip() for m in metrics]
@@ -319,9 +380,71 @@ def kernel(
         prefix = output_prefix
         if prefix is None:
             prefix = tempfile.mkdtemp(prefix="nspy_")
-            prefix = os.path.join(prefix, "")  # Adds a trailing forward/backward slash
+            prefix = os.path.join(prefix, "")  # Adds a trailing path separator
         else:
             os.makedirs(os.path.dirname(prefix) or ".", exist_ok=True)
+
+        # Normalize info_collectors: convert decorated functions to
+        # (name, callback, scope) tuples with a canonical string scope.
+        valid_scopes = {s.value for s in CollectionScope}
+
+        def _canonical_scope(scope: Any, label: str) -> str:
+            if isinstance(scope, CollectionScope):
+                return scope.value
+            if isinstance(scope, str) and scope in valid_scopes:
+                return scope
+            raise ValueError(
+                f"Invalid scope {scope!r} for collector {label}. "
+                f"Expected one of {sorted(valid_scopes)} or a CollectionScope."
+            )
+
+        normalized_collectors = None
+        if info_collectors:
+            normalized_collectors = []
+            for collector in info_collectors:
+                if isinstance(collector, InfoCollector):
+                    # An InfoCollector instance (the exported public class).
+                    normalized_collectors.append(
+                        (
+                            collector.name,
+                            collector.callback,
+                            _canonical_scope(collector.scope, repr(collector.name)),
+                        )
+                    )
+                elif isinstance(collector, tuple):
+                    # Raw tuple format: (name, callback, scope)
+                    if len(collector) != 3:
+                        raise ValueError(
+                            "Tuple-format info collector must be "
+                            f"(name, callback, scope); got {collector!r}."
+                        )
+                    name, callback, scope = collector
+                    if not isinstance(name, str) or not callable(callback):
+                        raise TypeError(
+                            "Tuple-format info collector must be "
+                            f"(str name, callable callback, scope); got {collector!r}."
+                        )
+                    normalized_collectors.append(
+                        (name, callback, _canonical_scope(scope, repr(name)))
+                    )
+                elif callable(collector):
+                    # Decorated function: extract metadata
+                    if hasattr(collector, "_nsight_collector_scope"):
+                        name = getattr(collector, "_nsight_collector_name")
+                        scope = getattr(collector, "_nsight_collector_scope")
+                        normalized_collectors.append(
+                            (name, collector, _canonical_scope(scope, repr(name)))
+                        )
+                    else:
+                        raise ValueError(
+                            f"Collector function {collector.__name__} is missing "
+                            "@nsight.experimental.collect(scope=...) decorator"
+                        )
+                else:
+                    raise TypeError(
+                        f"Invalid collector type: {type(collector)}. "
+                        "Expected tuple (name, callback, scope) or decorated function."
+                    )
 
         settings = collection.core.ProfileSettings(
             configs=configs,
@@ -336,6 +459,7 @@ def kernel(
             thermal_device=thermal_device,
             output_prefix=prefix,
             output_csv=output_csv,
+            info_collectors=normalized_collectors,
         )
         ncu = collection.ncu.NCUCollector(
             metrics=metrics,

--- a/nsight/annotation.py
+++ b/nsight/annotation.py
@@ -9,6 +9,7 @@ from typing import Any
 import nvtx
 
 import nsight.utils as utils
+from nsight import info_collector
 from nsight.exceptions import CUDA_CORE_UNAVAILABLE_MSG
 
 # Thread-local storage for tracking annotations
@@ -162,6 +163,8 @@ class annotate:
 
         add_active_annotation(self.name)
         _set_in_annotation(True)
+        # Collect annotation-scope information
+        info_collector.collect_for_annotation(self.name)
         self._range_id = nvtx.start_range(message=self.name, domain=utils.NVTX_DOMAIN)
         return self
 

--- a/nsight/collection/core.py
+++ b/nsight/collection/core.py
@@ -7,17 +7,20 @@ import functools
 import importlib.util
 import inspect
 import os
+import pickle
 import threading
 import time
 import warnings
 from collections.abc import Callable, Collection, Iterable, Sequence
-from typing import Any, List, Literal, Mapping
+from typing import Any, Literal, Mapping
 
 import numpy as np
 import pandas as pd
 
 from nsight import annotation, exceptions, thermovision, transformation, utils
 from nsight.utils import VerbosityLevel
+
+NormalizedInfoCollector = tuple[str, Callable[..., Any], str]
 
 
 def _get_regular_params(
@@ -232,9 +235,115 @@ def _sanitize_configs(
     return configs  # type: ignore[return-value]
 
 
+def _picklable_or_none(value: Any) -> Any:
+    """Return ``value`` if it can be pickled, otherwise None."""
+    try:
+        pickle.dumps(value)
+        return value
+    except Exception:
+        return None
+
+
+def _sanitize_for_pickle(runs: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    """Replace any non-picklable collected value with None, preserving structure.
+
+    Used as a fallback when serializing the full collected-info list fails
+    because a collector returned something unserializable (a CUDA stream, file
+    handle, lambda, ...). Degrading the offending value to None keeps the rest of
+    the run's data instead of losing everything.
+    """
+    sanitized: list[dict[str, Any]] = []
+    for run in runs:
+        new = dict(run)
+        new["config"] = _picklable_or_none(run.get("config"))
+        new["once_info"] = {
+            k: _picklable_or_none(v) for k, v in run.get("once_info", {}).items()
+        }
+        new["config_info"] = {
+            k: _picklable_or_none(v) for k, v in run.get("config_info", {}).items()
+        }
+        annotation_info = []
+        for entry in run.get("annotation_info", []):
+            new_entry = dict(entry)
+            new_entry["config"] = _picklable_or_none(entry.get("config"))
+            new_entry["data"] = {
+                k: _picklable_or_none(v) for k, v in entry.get("data", {}).items()
+            }
+            annotation_info.append(new_entry)
+        new["annotation_info"] = annotation_info
+        sanitized.append(new)
+    return sanitized
+
+
+def _serialize_collected_info(
+    runs: Sequence[Mapping[str, Any]],
+) -> tuple[bytes, bool] | None:
+    """Serialize collected info, replacing only non-picklable values.
+
+    Serialization is completed in memory before opening the output file. This
+    keeps collector-value failures separate from filesystem failures such as a
+    full disk or an unwritable output directory.
+
+    Returns:
+        The serialized payload and whether sanitization was required, or
+        ``None`` when the sanitized data still cannot be serialized.
+    """
+    try:
+        return pickle.dumps(runs), False
+    except Exception as exc:
+        sanitized = _sanitize_for_pickle(runs)
+        try:
+            payload = pickle.dumps(sanitized)
+        except Exception as fallback_exc:
+            warnings.warn(
+                "Failed to serialize custom info after replacing non-picklable "
+                f"values ({type(fallback_exc).__name__}: {fallback_exc}).",
+                category=RuntimeWarning,
+                stacklevel=2,
+            )
+            return None
+
+        warnings.warn(
+            f"Some collected info was not picklable ({type(exc).__name__}: {exc}); "
+            "non-picklable collector values have been replaced with None.",
+            category=RuntimeWarning,
+            stacklevel=2,
+        )
+        return payload, True
+
+
+def _save_collected_info(
+    info_file: str,
+    runs: Sequence[Mapping[str, Any]],
+    verbosity: VerbosityLevel,
+) -> bool:
+    """Serialize and save collected info without conflating failure causes."""
+    serialized = _serialize_collected_info(runs)
+    if serialized is None:
+        return False
+
+    payload, sanitized = serialized
+    try:
+        with open(info_file, "wb") as output_file:
+            output_file.write(payload)
+    except OSError as exc:
+        warnings.warn(
+            f"Failed to save custom info to {info_file} "
+            f"({type(exc).__name__}: {exc}).",
+            category=RuntimeWarning,
+            stacklevel=2,
+        )
+        return False
+
+    if verbosity >= VerbosityLevel.INFO:
+        suffix = " (sanitized)" if sanitized else ""
+        print(f"[NSIGHT-PYTHON] Saved collected info{suffix} to {info_file}")
+    return True
+
+
 def run_profile_session(
     func: Callable[..., None],
-    configs: List[Sequence[Any]],
+    configs: list[Sequence[Any]],
     runs: int,
     verbosity: VerbosityLevel,
     thermal_mode: Literal["auto", "manual", "off"],
@@ -242,11 +351,15 @@ def run_profile_session(
     thermal_cont: int | None = None,
     thermal_timeout: int | None = None,
     thermal_device: int | None = None,
+    info_collectors_list: list[NormalizedInfoCollector] | None = None,
+    output_prefix: str | None = None,
 ) -> None:
 
     if verbosity >= VerbosityLevel.INFO:
         print("")
         print("")
+
+    output_detailed = verbosity >= VerbosityLevel.DEBUG
 
     # Initialize thermal controller if needed (unless mode is "off")
     thermal_controller = None
@@ -277,6 +390,57 @@ def run_profile_session(
     show_return_type_warning = False
     config_lengths: list[int] = list()
 
+    # Parse info collectors
+    from nsight import info_collector
+
+    info_collector.reset_collector_failure_warnings()
+
+    once_collectors = []
+    config_collectors = []
+    run_collectors = []
+    annotation_collectors = []
+    if info_collectors_list:
+        for name, callback, scope in info_collectors_list:
+            try:
+                scope_enum = info_collector.CollectionScope(scope)
+            except ValueError as exc:
+                raise ValueError(
+                    f"Invalid scope '{scope}' for collector '{name}'. Must be "
+                    "'once', 'config', 'run', or 'annotation'."
+                ) from exc
+
+            collector_obj = info_collector.InfoCollector(
+                name=name, callback=callback, scope=scope_enum
+            )
+            if scope_enum == info_collector.CollectionScope.ONCE:
+                once_collectors.append(collector_obj)
+            elif scope_enum == info_collector.CollectionScope.CONFIG:
+                config_collectors.append(collector_obj)
+            elif scope_enum == info_collector.CollectionScope.RUN:
+                run_collectors.append(collector_obj)
+            else:  # ANNOTATION scope
+                annotation_collectors.append(collector_obj)
+
+    # Collect "once" scope information before any configs
+    once_info = {}
+    for collector in once_collectors:
+        try:
+            once_info[collector.name] = collector.collect()
+            if output_detailed:
+                print(
+                    f"[NSIGHT-PYTHON] Collected {collector.name}: {once_info[collector.name]}"
+                )
+        except Exception as e:
+            once_info[collector.name] = None
+            info_collector.warn_collector_failure(collector.name, "once", e)
+            if output_detailed:
+                print(
+                    f"[NSIGHT-PYTHON] Warning: Failed to collect '{collector.name}': {e}"
+                )
+
+    # Store collected info for each run
+    collected_info_per_run = []
+
     for c in configs:
         sig = inspect.signature(func)
         required_count, total_count = _count_params(sig)
@@ -305,6 +469,29 @@ def run_profile_session(
         if verbosity >= VerbosityLevel.INFO:
             utils.print_config(total_configs, curr_config, c, overwrite_output)
 
+        # Collect configuration information once, then repeat it for each run
+        # belonging to this configuration when constructing the raw rows.
+        config_info = {}
+        for collector in config_collectors:
+            try:
+                collector_args = info_collector.bind_args_to_signature(
+                    collector.callback, (), c
+                )
+                config_info[collector.name] = collector.collect(*collector_args)
+                if output_detailed:
+                    print(
+                        f"[NSIGHT-PYTHON] Collected {collector.name}: "
+                        f"{config_info[collector.name]}"
+                    )
+            except Exception as e:
+                config_info[collector.name] = None
+                info_collector.warn_collector_failure(collector.name, "config", e)
+                if output_detailed:
+                    print(
+                        f"[NSIGHT-PYTHON] Warning: Failed to collect "
+                        f"'{collector.name}' for config {c}: {e}"
+                    )
+
         for i in range(runs):
             start_time = time.time()
             curr_run += 1
@@ -314,12 +501,55 @@ def run_profile_session(
             # Clear active annotations before each run
             annotation.clear_active_annotations()
 
+            # Collect information that can change between repeated runs.
+            run_collected_info = {}
+            for collector in run_collectors:
+                try:
+                    collector_args = info_collector.bind_args_to_signature(
+                        collector.callback, (), c
+                    )
+                    run_collected_info[collector.name] = collector.collect(
+                        *collector_args
+                    )
+                    if output_detailed:
+                        print(
+                            f"[NSIGHT-PYTHON] Collected {collector.name}: "
+                            f"{run_collected_info[collector.name]}"
+                        )
+                except Exception as e:
+                    run_collected_info[collector.name] = None
+                    info_collector.warn_collector_failure(collector.name, "run", e)
+                    if output_detailed:
+                        print(
+                            f"[NSIGHT-PYTHON] Warning: Failed to collect "
+                            f"'{collector.name}' for run {i} of config {c}: {e}"
+                        )
+
+            # Set up annotation collectors for this run
+            info_collector.set_annotation_collectors(
+                annotation_collectors, tuple(c), output_detailed
+            )
+            info_collector.clear_annotation_data()
+
             # Run the function with the config, splitting into positional
             # and keyword-only args based on the function signature
             pos_args, kw_args = _bind_config_to_signature(sig, c)
             result = func(*pos_args, **kw_args)  # type: ignore[func-returns-value]
             if result is not None:
                 show_return_type_warning = True
+
+            # Collect annotation-scope data after the run
+            annotation_data = info_collector.get_collected_annotation_data()
+
+            # Store collected info for this run
+            run_info = {
+                "config": c,
+                "run_idx": i,
+                "once_info": once_info,
+                "config_info": {**config_info, **run_collected_info},
+                "annotation_info": annotation_data,  # List of per-annotation data
+            }
+            collected_info_per_run.append(run_info)
 
             elapsed_time = time.time() - start_time
             if curr_run > 1:
@@ -340,6 +570,10 @@ def run_profile_session(
                     )
                 progress_time = time.time()
 
+    # Do not leak collectors into annotations entered after profiling completes.
+    info_collector.set_annotation_collectors([], ())
+    info_collector.clear_annotation_data()
+
     # Update progress bar at end so it shows 100%
     if verbosity >= VerbosityLevel.INFO:
         utils.print_progress_bar(
@@ -359,6 +593,11 @@ def run_profile_session(
             category=RuntimeWarning,
             stacklevel=external_stacklevel,
         )
+
+    # Save collected info to a file if we have collectors
+    if info_collectors_list and output_prefix:
+        info_file = f"{output_prefix}collected_info.pkl"
+        _save_collected_info(info_file, collected_info_per_run, verbosity)
 
 
 @dataclasses.dataclass
@@ -476,6 +715,18 @@ class ProfileSettings:
     Controls whether to output raw and processed profiling data to CSV files
     """
 
+    info_collectors: list[NormalizedInfoCollector] | None
+    """
+    List of custom information collectors (normalized format).
+    Each is a tuple of (name, callback, scope) where:
+    - name: str - column name in DataFrame
+    - callback: Callable - function to collect the information
+    - scope: str - "once", "config", "run", or "annotation"
+
+    Note: This is the internal normalized format. Users pass decorated functions
+    or tuples to @nsight.analyze.kernel, which are normalized here.
+    """
+
 
 class ProfileResults:
     """
@@ -577,6 +828,13 @@ class NsightProfiler:
         self, func: Callable[..., None]
     ) -> Callable[..., ProfileResults | None]:
         func._nspy_ncu_run_id = 0  # type: ignore[attr-defined]
+
+        # Fail fast (before starting the profiling session) on collector names
+        # that would silently clobber profiler columns or function-arg columns.
+        if self.settings.info_collectors:
+            from nsight import info_collector
+
+            info_collector.validate_collectors(self.settings.info_collectors, func)
 
         @functools.wraps(func)
         def wrapper(

--- a/nsight/collection/ncu.py
+++ b/nsight/collection/ncu.py
@@ -20,7 +20,7 @@ from typing import Any, Literal
 
 import pandas as pd
 
-from nsight import exceptions, extraction, utils
+from nsight import exceptions, extraction, info_collector, utils
 from nsight.collection import core
 from nsight.exceptions import NCUErrorContext
 from nsight.utils import VerbosityLevel
@@ -425,9 +425,15 @@ class NCUCollector(core.NsightCollector):
                 settings.thermal_cont,
                 settings.thermal_timeout,
                 settings.thermal_device,
+                settings.info_collectors,
+                settings.output_prefix,
             )
         finally:
-            end_profiling()
+            try:
+                end_profiling()
+            finally:
+                info_collector.set_annotation_collectors([], ())
+                info_collector.clear_annotation_data()
 
         return_code = ncu_process.wait()
         if return_code != 0:
@@ -450,6 +456,17 @@ class NCUCollector(core.NsightCollector):
                 f"[NSIGHT-PYTHON] Refer to {log_path} for the NVIDIA Nsight Compute CLI logs"
             )
 
+        # Numeric values collected per configuration, run, or annotation vary
+        # across raw rows and are aggregated alongside profiling metrics.
+        config_scope_columns = []
+        annotation_scope_columns = []
+        if settings.info_collectors:
+            for name, _callback, scope in settings.info_collectors:
+                if scope in ("config", "run"):
+                    config_scope_columns.append(name)
+                elif scope == "annotation":
+                    annotation_scope_columns.append(name)
+
         df = extraction.extract_df_from_report(
             report_path,
             self.metrics,
@@ -460,6 +477,10 @@ class NCUCollector(core.NsightCollector):
             self.ignore_kernel_list,  # type: ignore[arg-type]
             settings.verbosity,
             self.combine_kernel_metrics,
+            settings.info_collectors,
+            config_scope_columns,
+            annotation_scope_columns,
+            info_prefix=settings.output_prefix or "",
         )
 
         return df

--- a/nsight/experimental.py
+++ b/nsight/experimental.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Experimental Nsight Python APIs.
+
+APIs in this module may change without the compatibility guarantees of the
+stable package surface.
+"""
+
+from collections.abc import Callable
+from typing import Any, TypeVar, overload
+
+from nsight.info_collector import CollectionScope
+
+_Collector = TypeVar("_Collector", bound=Callable[..., Any])
+
+
+def _canonical_scope(scope: CollectionScope | str) -> str:
+    """Return a validated string representation of a collection scope."""
+    if isinstance(scope, CollectionScope):
+        return scope.value
+    try:
+        return CollectionScope(scope).value
+    except (TypeError, ValueError) as exc:
+        valid_scopes = ", ".join(repr(item.value) for item in CollectionScope)
+        raise ValueError(
+            f"Invalid collection scope {scope!r}. Expected one of {valid_scopes} "
+            "or a CollectionScope."
+        ) from exc
+
+
+@overload
+def collect(
+    _func: _Collector,
+    *,
+    scope: CollectionScope | str,
+) -> _Collector: ...
+
+
+@overload
+def collect(
+    _func: None = None,
+    *,
+    scope: CollectionScope | str,
+) -> Callable[[_Collector], _Collector]: ...
+
+
+def collect(
+    _func: _Collector | None = None,
+    *,
+    scope: CollectionScope | str,
+) -> _Collector | Callable[[_Collector], _Collector]:
+    """Mark a function as a custom information collector.
+
+    Args:
+        _func: Function to decorate. This is normally supplied by decorator
+            syntax, but direct calls are also supported.
+        scope: When the function is called. Supported values are
+            :class:`nsight.CollectionScope` members or their string values:
+            ``"once"``, ``"config"``, ``"run"``, and ``"annotation"``.
+
+    Examples:
+        Decorator syntax::
+
+            @nsight.experimental.collect(scope=nsight.CollectionScope.RUN)
+            def gpu_temperature(*config_args):
+                return read_gpu_temperature()
+
+        Direct-call syntax::
+
+            gpu_temperature = nsight.experimental.collect(
+                gpu_temperature, scope="run"
+            )
+    """
+    canonical_scope = _canonical_scope(scope)
+
+    def decorator(func: _Collector) -> _Collector:
+        if not callable(func):
+            raise TypeError("collect can only decorate a callable")
+        setattr(func, "_nsight_collector_scope", canonical_scope)
+        setattr(func, "_nsight_collector_name", func.__name__)
+        return func
+
+    if _func is None:
+        return decorator
+    return decorator(_func)

--- a/nsight/extraction.py
+++ b/nsight/extraction.py
@@ -86,6 +86,10 @@ def extract_df_from_report(
     ignore_kernel_list: List[str] | None,
     verbosity: VerbosityLevel,
     combine_kernel_metrics: Callable[[float, float], float] | None = None,
+    info_collectors_list: List[Tuple[str, Callable[..., Any], str]] | None = None,
+    config_scope_columns: List[str] | None = None,
+    annotation_scope_columns: List[str] | None = None,
+    info_prefix: str | None = None,
 ) -> pd.DataFrame:
     """
     Extracts and aggregates profiling results from an NVIDIA Nsight Compute report.
@@ -99,7 +103,7 @@ def extract_df_from_report(
         derive_metric: Function to transform the raw metric values with config values.
         ignore_kernel_list: Kernel names to ignore in the analysis.
         combine_kernel_metrics: Function to merge multiple kernel metrics.
-        verbose: Toggles the printing of extraction progress.
+        verbosity: Controls display of extraction progress.
 
     Returns:
         A DataFrame containing the extracted and transformed performance data.
@@ -142,6 +146,50 @@ def extract_df_from_report(
         if p.kind
         not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
     }
+
+    # Load collected info from the pickle file if it exists
+    collected_info_per_run = []
+    custom_info_names = set()
+    if info_collectors_list:
+        import os
+
+        # Use the explicitly-provided prefix when available so the read path
+        # matches the collection-session write path exactly.
+        # Fall back to reconstructing from the report directory for direct callers.
+        if info_prefix is None:
+            report_dir = os.path.dirname(report_path)
+            info_prefix = os.path.join(report_dir, "") if report_dir else ""
+
+        # Column names come from the collector metadata (authoritative), not from
+        # the first run's collected data. Deriving from run 0 dropped any
+        # annotation-scope collector whose annotation was not entered on run 0.
+        custom_info_names = {name for name, _callback, _scope in info_collectors_list}
+
+        info_file = f"{info_prefix}collected_info.pkl"
+        if os.path.exists(info_file):
+            import pickle
+
+            with open(info_file, "rb") as f:
+                collected_info_per_run = pickle.load(f)
+            if not isinstance(collected_info_per_run, list):
+                warnings.warn(
+                    f"Collected info file {info_file} is malformed "
+                    f"(expected a list, got {type(collected_info_per_run).__name__}); "
+                    "ignoring custom info.",
+                    category=RuntimeWarning,
+                    stacklevel=2,
+                )
+                collected_info_per_run = []
+            elif verbosity >= VerbosityLevel.INFO:
+                print(f"[NSIGHT-PYTHON] Loaded collected info from {info_file}")
+        else:
+            if verbosity >= VerbosityLevel.INFO:
+                print(
+                    f"[NSIGHT-PYTHON] Warning: No collected info file found at {info_file}"
+                )
+
+    # Create arrays for custom info collectors
+    custom_info_arrays: dict[str, list[Any]] = {name: [] for name in custom_info_names}
 
     # Extract all profiling data
     profiling_data: dict[str, list[utils.NCUActionData]] = {}
@@ -218,7 +266,9 @@ def extract_df_from_report(
                 )
             )
 
-        for conf, data in zip(configs_repeated, action_data):
+        for idx, (conf, data) in enumerate(
+            zip(configs_repeated, action_data, strict=True)
+        ):
             compute_clocks.append(data.compute_clock)
             memory_clocks.append(data.memory_clock)
             gpus.append(data.gpu)
@@ -311,6 +361,44 @@ def extract_df_from_report(
                     continue
                 arg_arrays[name].append(next(config_iter))
 
+            # Add custom collected information
+            if (
+                collected_info_per_run
+                and idx < len(collected_info_per_run)
+                and isinstance(collected_info_per_run[idx], dict)
+            ):
+                run_info = collected_info_per_run[idx]
+                # Add once info. Guard against pickle keys that are not in the
+                # metadata-derived custom_info_names (e.g. a stale collected_info
+                # .pkl written by a different set of collectors); such keys have
+                # no column and are ignored rather than raising KeyError.
+                for name, value in run_info.get("once_info", {}).items():
+                    if name in custom_info_arrays:
+                        custom_info_arrays[name].append(value)
+                # Add config info
+                for name, value in run_info.get("config_info", {}).items():
+                    if name in custom_info_arrays:
+                        custom_info_arrays[name].append(value)
+                # Add annotation info - match by annotation name
+                annotation_info_list = run_info.get("annotation_info", [])
+                annotation_data_for_this = {}
+                for ann_data in annotation_info_list:
+                    if ann_data.get("annotation") == annotation:
+                        annotation_data_for_this = ann_data.get("data", {})
+                        break
+                for name in custom_info_names:
+                    if name in annotation_data_for_this:
+                        custom_info_arrays[name].append(annotation_data_for_this[name])
+                    elif name not in run_info.get(
+                        "once_info", {}
+                    ) and name not in run_info.get("config_info", {}):
+                        # This is an annotation-scope collector that wasn't collected for this annotation
+                        custom_info_arrays[name].append(None)
+            else:
+                # No collected info available for this run, append None
+                for name in custom_info_names:
+                    custom_info_arrays[name].append(None)
+
     # Create the DataFrame with the initial columns
     df_data = {
         "Annotation": annotations,
@@ -324,7 +412,12 @@ def extract_df_from_report(
         "Unit": units,
     }
 
-    # Add each array in arg_arrays to the DataFrame
+    # Add custom info collector data BEFORE function parameters
+    # This is important because transformation.py expects function params to be the LAST columns
+    for collector_name, collector_values in custom_info_arrays.items():
+        df_data[collector_name] = collector_values
+
+    # Add each array in arg_arrays to the DataFrame (function parameters LAST)
     for arg_name, arg_values in arg_arrays.items():
         df_data[arg_name] = arg_values
 
@@ -349,6 +442,15 @@ def extract_df_from_report(
             "Unit": all_transformed_values_units,
         }
 
+        # Custom-info columns must be added BEFORE the function-parameter columns
+        # (mirroring df_data above) so transformation.py still treats the function
+        # params as the LAST columns. Without this, derived-metric rows would get
+        # NaN/None for every collector column after the pd.concat below. The
+        # arrays are populated once per base row in the same loop, so they align
+        # row-for-row with the transformed rows.
+        for collector_name, collector_values in custom_info_arrays.items():
+            transformed_df_data[collector_name] = collector_values
+
         for arg_name, arg_values in arg_arrays.items():
             transformed_df_data[arg_name] = arg_values
 
@@ -360,5 +462,11 @@ def extract_df_from_report(
 
         # Concat the two dataframes
         df = pd.concat([df, transformed_df], ignore_index=True)
+
+    # Mark config-scope and annotation-scope columns for aggregation during transformation
+    if config_scope_columns:
+        df.attrs["config_scope_columns"] = config_scope_columns
+    if annotation_scope_columns:
+        df.attrs["annotation_scope_columns"] = annotation_scope_columns
 
     return df

--- a/nsight/info_collector.py
+++ b/nsight/info_collector.py
@@ -1,0 +1,364 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Info collector utilities for collecting custom information during profiling.
+
+This module provides the core data structures for custom information collectors
+that can be passed to the @nsight.analyze.kernel decorator.
+"""
+
+import inspect
+import warnings
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+
+from nsight import exceptions
+
+
+class CollectionScope(Enum):
+    """
+    Defines when a collector should be invoked during profiling.
+
+    Attributes:
+        ONCE: Collector is invoked once at the start of profiling.
+              Use for static information like driver version, CUDA version, etc.
+        CONFIG: Collector is invoked once for each configuration.
+                Use for configuration-derived information that does not change
+                between repeated runs.
+        RUN: Collector is invoked once for every run of each configuration.
+             Use for dynamic information like clocks, temperature, memory usage, etc.
+        ANNOTATION: Collector is invoked at the start of each annotated region.
+                    Use for per-annotation state like cache status, active threads, etc.
+    """
+
+    ONCE = "once"
+    CONFIG = "config"
+    RUN = "run"
+    ANNOTATION = "annotation"
+
+
+@dataclass
+class InfoCollector:
+    """
+    Data class representing an information collector.
+
+    Attributes:
+        name: The column name in the resulting DataFrame.
+        callback: Function to call to collect the information.
+        scope: When this collector should be invoked (ONCE, CONFIG, RUN, or
+            ANNOTATION).
+
+    Example:
+        >>> from nsight.info_collector import InfoCollector, CollectionScope
+        >>>
+        >>> # Create a ONCE scope collector
+        >>> def get_version():
+        ...     return "1.0.0"
+        >>> version_collector = InfoCollector("Version", get_version, CollectionScope.ONCE)
+        >>>
+        >>> # Create a CONFIG scope collector
+        >>> def sum_args(*args):
+        ...     return sum(args)
+        >>> sum_collector = InfoCollector("Sum", sum_args, CollectionScope.CONFIG)
+        >>>
+        >>> # Create a RUN scope collector
+        >>> def current_temperature(*args):
+        ...     return 42
+        >>> temperature_collector = InfoCollector(
+        ...     "Temperature", current_temperature, CollectionScope.RUN
+        ... )
+        >>>
+        >>> # Create an ANNOTATION scope collector
+        >>> def get_annotation_info(annotation_name, *config_args):
+        ...     return f"{annotation_name}_{config_args[0]}"
+        >>> ann_collector = InfoCollector("AnnInfo", get_annotation_info, CollectionScope.ANNOTATION)
+    """
+
+    name: str
+    callback: Callable[..., Any]
+    scope: CollectionScope
+
+    def collect(self, *args: Any) -> Any:
+        """
+        Collect information by invoking the callback.
+
+        Args:
+            *args: Arguments passed to the callback. ONCE-scope collectors
+                receive no arguments, CONFIG- and RUN-scope collectors receive
+                the configuration arguments, and ANNOTATION-scope collectors
+                receive the annotation name followed by the configuration
+                arguments.
+
+        Returns:
+            The collected information.
+        """
+        if self.scope == CollectionScope.ONCE:
+            # For ONCE scope, we don't pass any arguments
+            return self.callback()
+        return self.callback(*args)
+
+
+# Column names that the profiler itself produces in the result DataFrame.
+# A custom collector may not reuse any of these, or it would silently overwrite
+# real profiling data (built-in columns) or aggregation outputs.
+RESERVED_COLUMN_NAMES = frozenset(
+    {
+        # Built-in columns from extraction.extract_df_from_report
+        "Annotation",
+        "Value",
+        "Metric",
+        "Kernel",
+        "GPU",
+        "Host",
+        "ComputeClock",
+        "MemoryClock",
+        "Unit",
+        # Aggregation outputs from transformation.aggregate_data
+        "AvgValue",
+        "StdDev",
+        "MinValue",
+        "MaxValue",
+        "NumRuns",
+        "CI95_Lower",
+        "CI95_Upper",
+        "RelativeStdDevPct",
+        "StableMeasurement",
+        "Geomean",
+        "Normalized",
+        "NormalizationValue",
+    }
+)
+
+
+def validate_collectors(
+    collectors: Sequence[Tuple[str, Callable[..., Any], str]],
+    func: Optional[Callable[..., Any]] = None,
+) -> None:
+    """Validate normalized ``(name, callback, scope)`` collector tuples.
+
+    Raises a clear ``ProfilerException`` (fail-fast, before any profiling work)
+    when a collector name would silently clobber another column:
+
+    * duplicate collector names (one would overwrite the other),
+    * a name colliding with a reserved profiler column (see
+      ``RESERVED_COLUMN_NAMES``),
+    * a name colliding with one of the decorated function's parameter names
+      (the parameter column would overwrite the collector column).
+
+    Args:
+        collectors: Normalized collector tuples.
+        func: The decorated function, used to detect parameter-name collisions.
+            Optional so the check can run before ``func`` is known.
+    """
+    seen: set[str] = set()
+    for entry in collectors:
+        name = entry[0]
+        if name in seen:
+            raise exceptions.ProfilerException(
+                f"Duplicate info collector name '{name}'. Each collector must "
+                "have a unique name (the function name becomes the column name)."
+            )
+        seen.add(name)
+        if name in RESERVED_COLUMN_NAMES:
+            raise exceptions.ProfilerException(
+                f"Info collector name '{name}' collides with a reserved profiler "
+                f"column. Reserved names: {sorted(RESERVED_COLUMN_NAMES)}."
+            )
+
+    if func is not None:
+        param_names = {
+            p.name
+            for p in inspect.signature(func).parameters.values()
+            if p.kind
+            not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+        }
+        for name in seen:
+            if name in param_names:
+                raise exceptions.ProfilerException(
+                    f"Info collector name '{name}' collides with a parameter of "
+                    f"'{func.__name__}'. Rename the collector so it does not shadow "
+                    "a function argument column."
+                )
+
+
+def bind_args_to_signature(
+    callback: Callable[..., Any],
+    leading: Sequence[Any],
+    config: Sequence[Any],
+) -> List[Any]:
+    """Compute the positional args to pass to a collector callback.
+
+    ``leading`` are mandatory leading args (e.g. the annotation name for
+    annotation-scope collectors); ``config`` is the (possibly default-padded)
+    config tuple. A collector that declares ``*args`` receives the full config;
+    a fixed-arity collector receives only as many leading config values as its
+    remaining positional parameters, so default-padded or extra config values do
+    not cause a spurious ``TypeError`` (which was previously swallowed, silently
+    nulling the column).
+    """
+    try:
+        params = list(inspect.signature(callback).parameters.values())
+    except (TypeError, ValueError):
+        # Builtins / C callables with no introspectable signature: pass all.
+        return list(leading) + list(config)
+
+    if any(p.kind == inspect.Parameter.VAR_POSITIONAL for p in params):
+        return list(leading) + list(config)
+
+    positional_params = [
+        p
+        for p in params
+        if p.kind
+        in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        )
+    ]
+    remaining = max(0, len(positional_params) - len(leading))
+    return list(leading) + list(config[:remaining])
+
+
+# Collectors that have already triggered a failure warning this session, so we
+# warn once per (scope, name) instead of once per run (which would be spammy).
+_warned_failures: set[str] = set()
+
+
+def reset_collector_failure_warnings() -> None:
+    """Reset warning de-duplication at the start of a profiling session."""
+    _warned_failures.clear()
+
+
+def warn_collector_failure(name: str, scope: str, exc: BaseException) -> None:
+    """Surface a collector failure regardless of the profiler's output mode.
+
+    Collector exceptions are swallowed (the column degrades to None), but a
+    collector that fails on every run would otherwise be completely invisible
+    in the default/quiet output modes. This emits a single RuntimeWarning the
+    first time a given collector fails, so the failure is never silent.
+    """
+    key = f"{scope}:{name}"
+    if key in _warned_failures:
+        return
+    _warned_failures.add(key)
+    warnings.warn(
+        f"Info collector '{name}' ({scope} scope) raised "
+        f"{type(exc).__name__}: {exc}. Its column will be None for failed runs.",
+        category=RuntimeWarning,
+        stacklevel=2,
+    )
+
+
+# Process-global state for annotation collectors and collected data.
+# Profiling runs exactly one session at a time, and annotated regions may be
+# entered from worker threads. This state is therefore intentionally
+# process-global rather than thread-local:
+# a thread-local store silently lost all annotation data whenever the kernel
+# was launched from a thread other than the one running run_profile_session.
+@dataclass
+class _AnnotationCollectorState:
+    """Process-global state for annotation collectors."""
+
+    collectors: List[InfoCollector] = field(default_factory=list)
+    current_config: tuple[Any, ...] = field(default_factory=tuple)
+    collected_data: List[Dict[str, Any]] = field(default_factory=list)
+    output_detailed: bool = False
+
+
+_state = _AnnotationCollectorState()
+
+
+def _get_state() -> _AnnotationCollectorState:
+    """Get the process-global annotation-collector state."""
+    return _state
+
+
+def set_annotation_collectors(
+    collectors: List[InfoCollector],
+    current_config: tuple[Any, ...],
+    output_detailed: bool = False,
+) -> None:
+    """
+    Set the annotation collectors and current config for this process.
+
+    This is called by run_profile_session before running each configuration.
+
+    Args:
+        collectors: List of ANNOTATION scope collectors.
+        current_config: The current configuration tuple.
+        output_detailed: Whether to print detailed output.
+    """
+    state = _get_state()
+    state.collectors = collectors
+    state.current_config = current_config
+    state.output_detailed = output_detailed
+
+
+def collect_for_annotation(annotation_name: str) -> Dict[str, Any]:
+    """
+    Collect information for an annotation.
+
+    This is called by the annotate context manager when entering an annotation.
+
+    Args:
+        annotation_name: Name of the annotation being entered.
+
+    Returns:
+        Dictionary mapping collector names to collected values.
+    """
+    state = _get_state()
+    if not state.collectors:
+        return {}
+
+    collected = {}
+
+    for collector in state.collectors:
+        try:
+            # Pass annotation name and current config to the collector, trimming
+            # extra (default-padded) config values for fixed-arity collectors.
+            collector_args = bind_args_to_signature(
+                collector.callback, (annotation_name,), state.current_config
+            )
+            value = collector.collect(*collector_args)
+            collected[collector.name] = value
+            if state.output_detailed:
+                print(
+                    f"[NSIGHT-PYTHON] Collected {collector.name} ({annotation_name}): {value}"
+                )
+        except Exception as e:
+            collected[collector.name] = None
+            warn_collector_failure(collector.name, "annotation", e)
+            if state.output_detailed:
+                print(
+                    f"[NSIGHT-PYTHON] Warning: Failed to collect '{collector.name}' for annotation '{annotation_name}': {e}"
+                )
+
+    # Store for later retrieval
+    state.collected_data.append(
+        {
+            "annotation": annotation_name,
+            "config": state.current_config,
+            "data": collected,
+        }
+    )
+
+    return collected
+
+
+def get_collected_annotation_data() -> List[Dict[str, Any]]:
+    """
+    Get all collected annotation data for the current profiling run.
+
+    Returns:
+        List of collected annotation data dictionaries (a copy).
+    """
+    state = _get_state()
+    # Return a copy to avoid reference issues when clearing for next run
+    return state.collected_data.copy()
+
+
+def clear_annotation_data() -> None:
+    """Clear all collected annotation data for the current profiling run."""
+    state = _get_state()
+    state.collected_data.clear()

--- a/nsight/transformation.py
+++ b/nsight/transformation.py
@@ -78,9 +78,25 @@ def aggregate_data(
         if col not in [*groupby_columns, "Value", "_original_order", *func_fields]
     ]
 
+    # Get config-scope and annotation-scope columns that should be aggregated (marked by extraction)
+    config_scope_columns = df.attrs.get("config_scope_columns", [])
+    annotation_scope_columns = df.attrs.get("annotation_scope_columns", [])
+
+    # Kernel can vary within a group due to a CUTLASS4 name suffix; use "first".
     for col in remaining_fields:
         if col == "Kernel":
             named_aggs[col] = (col, "first")
+        elif col in config_scope_columns or col in annotation_scope_columns:
+            # Config-scope and annotation-scope collectors vary across runs, so aggregate them
+            # But only use numeric aggregations if the data is actually numeric
+            if pd.api.types.is_numeric_dtype(df[col]):
+                named_aggs[f"{col}_Avg"] = (col, "mean")
+                named_aggs[f"{col}_Std"] = (col, "std")
+                named_aggs[f"{col}_Min"] = (col, "min")
+                named_aggs[f"{col}_Max"] = (col, "max")
+            else:
+                # For non-numeric data, just take the first value
+                named_aggs[col] = (col, "first")
         else:
             named_aggs[col] = (  # type: ignore[assignment]
                 col,

--- a/tests/test_info_collector.py
+++ b/tests/test_info_collector.py
@@ -1,0 +1,454 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for the info_collector module.
+"""
+
+import builtins
+import pickle
+import threading
+import warnings
+from typing import Any
+
+import pytest
+
+import nsight
+from nsight import exceptions, info_collector
+from nsight.collection import core
+from nsight.info_collector import CollectionScope, InfoCollector
+
+
+class TestInfoCollector:
+    """Tests for InfoCollector dataclass."""
+
+    def test_collect_once_scope(self) -> None:
+        """Test collecting with ONCE scope."""
+
+        def callback() -> str:
+            return "test_value"
+
+        collector = InfoCollector(
+            name="TestCollector", callback=callback, scope=CollectionScope.ONCE
+        )
+
+        result = collector.collect()
+        assert result == "test_value"
+
+    def test_collect_config_scope(self) -> None:
+        """Test collecting with CONFIG scope."""
+
+        def callback(x: int, y: int) -> int:
+            return x + y
+
+        collector = InfoCollector(
+            name="TestCollector", callback=callback, scope=CollectionScope.CONFIG
+        )
+
+        result = collector.collect(10, 20)
+        assert result == 30
+
+    def test_collect_config_scope_with_args(self) -> None:
+        """Test CONFIG scope collector receives config args."""
+
+        def callback(*args: int) -> int:
+            return sum(args)
+
+        collector = InfoCollector(
+            name="SumCollector", callback=callback, scope=CollectionScope.CONFIG
+        )
+
+        result = collector.collect(1, 2, 3, 4, 5)
+        assert result == 15
+
+    def test_collect_run_scope_with_args(self) -> None:
+        """Test RUN scope collector receives config args."""
+
+        collector = InfoCollector(
+            name="RunCollector",
+            callback=lambda value: value * 2,
+            scope=CollectionScope.RUN,
+        )
+
+        assert collector.collect(21) == 42
+
+
+class TestExperimentalCollect:
+    """Tests for the unified experimental collector decorator."""
+
+    def test_decorator_accepts_enum_scope(self) -> None:
+        @nsight.experimental.collect(scope=CollectionScope.CONFIG)
+        def collector(value: int) -> int:
+            return value
+
+        assert collector._nsight_collector_scope == "config"  # type: ignore[attr-defined]
+        assert collector._nsight_collector_name == "collector"  # type: ignore[attr-defined]
+
+    def test_direct_call_accepts_string_scope(self) -> None:
+        def callback() -> int:
+            return 1
+
+        collector = nsight.experimental.collect(callback, scope="once")
+
+        assert collector is callback
+        assert collector._nsight_collector_scope == "once"  # type: ignore[attr-defined]
+
+    def test_rejects_invalid_scope(self) -> None:
+        with pytest.raises(ValueError, match="Invalid collection scope"):
+            nsight.experimental.collect(scope="invalid")
+
+
+def test_profile_session_scope_invocation_counts(tmp_path: Any) -> None:
+    """CONFIG runs once per config, while RUN and ANNOTATION run repeatedly."""
+    calls: dict[str, list[Any]] = {
+        "once": [],
+        "config": [],
+        "run": [],
+        "annotation": [],
+    }
+
+    def collect_once() -> str:
+        calls["once"].append(None)
+        return "static"
+
+    def collect_config(value: int) -> int:
+        calls["config"].append(value)
+        return value
+
+    def collect_run(value: int) -> int:
+        calls["run"].append(value)
+        return value
+
+    def collect_annotation(annotation_name: str, value: int) -> str:
+        calls["annotation"].append((annotation_name, value))
+        return annotation_name
+
+    def kernel(value: int) -> None:
+        info_collector.collect_for_annotation("region")
+
+    core.run_profile_session(
+        kernel,
+        [(1,), (2,)],
+        runs=3,
+        verbosity=nsight.VerbosityLevel.SILENT,
+        thermal_mode="off",
+        info_collectors_list=[
+            ("once", collect_once, "once"),
+            ("config", collect_config, "config"),
+            ("run", collect_run, "run"),
+            ("annotation", collect_annotation, "annotation"),
+        ],
+        output_prefix=f"{tmp_path}/",
+    )
+
+    assert calls["once"] == [None]
+    assert calls["config"] == [1, 2]
+    assert calls["run"] == [1, 1, 1, 2, 2, 2]
+    assert calls["annotation"] == [
+        ("region", 1),
+        ("region", 1),
+        ("region", 1),
+        ("region", 2),
+        ("region", 2),
+        ("region", 2),
+    ]
+    assert info_collector.collect_for_annotation("after_profile") == {}
+
+
+def test_profile_session_resets_failure_warnings(tmp_path: Any) -> None:
+    """The same failing collector warns once in each profiling session."""
+
+    def failing_collector() -> None:
+        raise RuntimeError("expected failure")
+
+    def kernel() -> None:
+        pass
+
+    with pytest.warns(RuntimeWarning, match="expected failure") as warnings_list:
+        for _ in range(2):
+            core.run_profile_session(
+                kernel,
+                [()],
+                runs=1,
+                verbosity=nsight.VerbosityLevel.SILENT,
+                thermal_mode="off",
+                info_collectors_list=[("failing", failing_collector, "run")],
+                output_prefix=f"{tmp_path}/",
+            )
+
+    assert len(warnings_list) == 2
+
+
+def test_non_picklable_collector_value_is_sanitized(tmp_path: Any) -> None:
+    """Only the non-picklable value is replaced before writing the file."""
+    info_file = tmp_path / "collected_info.pkl"
+    collected_info: list[dict[str, Any]] = [
+        {
+            "config": (),
+            "run_idx": 0,
+            "once_info": {"good": "value", "bad": lambda: None},
+            "config_info": {},
+            "annotation_info": [],
+        }
+    ]
+
+    with pytest.warns(RuntimeWarning, match="not picklable"):
+        saved = core._save_collected_info(
+            str(info_file), collected_info, nsight.VerbosityLevel.SILENT
+        )
+
+    assert saved
+    with info_file.open("rb") as file:
+        saved_info = pickle.load(file)
+    assert saved_info[0]["once_info"] == {"good": "value", "bad": None}
+
+
+def test_collected_info_io_failure_is_reported_separately(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A disk write failure is not reported as a non-picklable value."""
+
+    def fail_open(*args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        raise OSError("disk full")
+
+    monkeypatch.setattr(builtins, "open", fail_open)
+
+    with pytest.warns(
+        RuntimeWarning, match="Failed to save.*disk full"
+    ) as warnings_list:
+        saved = core._save_collected_info(
+            "/unwritable/collected_info.pkl",
+            [],
+            nsight.VerbosityLevel.SILENT,
+        )
+
+    assert not saved
+    assert "not picklable" not in str(warnings_list[0].message)
+
+
+class TestCollectorIntegration:
+    """Integration tests for info collectors."""
+
+    def test_real_world_scenario(self) -> None:
+        """Test a realistic scenario with multiple collectors."""
+
+        # Simulate collecting static info
+        def get_driver_version() -> str:
+            return "555.42"
+
+        def get_cuda_version() -> str:
+            return "12.6"
+
+        # Simulate collecting dynamic info
+        def get_temperature(*config_args: int) -> int:
+            # In real scenario, this would query nvidia-smi
+            # For testing, we'll just use the first arg
+            return 50 + config_args[0] if config_args else 50
+
+        def compute_size(*config_args: int) -> int:
+            if len(config_args) >= 2:
+                return config_args[0] * config_args[1]
+            return 0
+
+        # Create collector objects directly
+        once_collectors = [
+            InfoCollector("DriverVersion", get_driver_version, CollectionScope.ONCE),
+            InfoCollector("CUDAVersion", get_cuda_version, CollectionScope.ONCE),
+        ]
+        config_collectors = [
+            InfoCollector("Temperature", get_temperature, CollectionScope.CONFIG),
+            InfoCollector("ComputedSize", compute_size, CollectionScope.CONFIG),
+        ]
+
+        # Collect once info
+        once_data = {c.name: c.collect() for c in once_collectors}
+
+        assert once_data["DriverVersion"] == "555.42"
+        assert once_data["CUDAVersion"] == "12.6"
+
+        # Collect config info for multiple configs
+        configs = [(512, 512), (1024, 1024), (2048, 2048)]
+
+        config_data = []
+        for config in configs:
+            row_data = {c.name: c.collect(*config) for c in config_collectors}
+            config_data.append(row_data)
+
+        # Verify config-specific data
+        assert config_data[0]["Temperature"] == 50 + 512
+        assert config_data[1]["Temperature"] == 50 + 1024
+        assert config_data[2]["Temperature"] == 50 + 2048
+
+        assert config_data[0]["ComputedSize"] == 512 * 512
+        assert config_data[1]["ComputedSize"] == 1024 * 1024
+        assert config_data[2]["ComputedSize"] == 2048 * 2048
+
+
+class TestValidateCollectors:
+    """Validation of collector names (fail-fast before profiling)."""
+
+    def test_rejects_duplicate_names(self) -> None:
+        with pytest.raises(exceptions.ProfilerException, match="Duplicate"):
+            info_collector.validate_collectors(
+                [
+                    ("dup", lambda: 1, "once"),
+                    ("dup", lambda: 2, "once"),
+                ]
+            )
+
+    def test_rejects_cross_scope_duplicate(self) -> None:
+        with pytest.raises(exceptions.ProfilerException, match="Duplicate"):
+            info_collector.validate_collectors(
+                [
+                    ("name", lambda: 1, "once"),
+                    ("name", lambda *a: 2, "annotation"),
+                ]
+            )
+
+    def test_rejects_reserved_column_name(self) -> None:
+        for reserved in ("Kernel", "GPU", "Value", "Annotation", "AvgValue"):
+            with pytest.raises(exceptions.ProfilerException, match="reserved"):
+                info_collector.validate_collectors([(reserved, lambda: 1, "once")])
+
+    def test_rejects_aggregation_output_name(self) -> None:
+        # Columns added by transformation.aggregate_data must also be reserved,
+        # otherwise a collector named after one is silently clobbered.
+        for reserved in ("Geomean", "CI95_Lower", "Normalized", "StableMeasurement"):
+            with pytest.raises(exceptions.ProfilerException, match="reserved"):
+                info_collector.validate_collectors([(reserved, lambda *a: 1, "config")])
+
+    def test_rejects_collision_with_function_param(self) -> None:
+        def kernel(n, dtype):  # type: ignore[no-untyped-def]
+            return None
+
+        with pytest.raises(exceptions.ProfilerException, match="parameter"):
+            info_collector.validate_collectors(
+                [("n", lambda *a: 1, "config")], func=kernel
+            )
+
+    def test_accepts_valid_collectors(self) -> None:
+        def kernel(n, dtype):  # type: ignore[no-untyped-def]
+            return None
+
+        # No exception expected.
+        info_collector.validate_collectors(
+            [
+                ("driver", lambda: "1.0", "once"),
+                ("temp", lambda *a: 1, "config"),
+            ],
+            func=kernel,
+        )
+
+
+class TestBindArgsToSignature:
+    """Config-to-collector argument binding (handles default-padded configs)."""
+
+    def test_var_positional_receives_full_config(self) -> None:
+        assert info_collector.bind_args_to_signature(lambda *a: a, (), (1, 2, 3)) == [
+            1,
+            2,
+            3,
+        ]
+
+    def test_fixed_arity_trims_extra_padded_values(self) -> None:
+        # Kernel had a defaulted 3rd param; config padded to len 3, but the
+        # collector only declares one argument -> it must receive just that one.
+        assert info_collector.bind_args_to_signature(lambda n: n, (), (1, 2, 3)) == [1]
+
+    def test_annotation_leading_arg_with_fixed_collector(self) -> None:
+        assert info_collector.bind_args_to_signature(
+            lambda annotation_name, n: None, ("add",), (1, 2, 3)
+        ) == ["add", 1]
+
+    def test_annotation_leading_arg_with_var_positional(self) -> None:
+        assert info_collector.bind_args_to_signature(
+            lambda annotation_name, *cfg: None, ("add",), (1, 2)
+        ) == ["add", 1, 2]
+
+
+class TestAnnotationStateMachine:
+    """GPU-free coverage of the thread/process-global annotation state machine."""
+
+    def test_get_collected_returns_independent_copy_across_runs(self) -> None:
+        """Regression: get_collected_annotation_data() must return a copy so a
+        later run's clear()/collect() cannot retroactively empty an earlier
+        run's snapshot (the bug the .copy() in get_collected_annotation_data
+        guards against)."""
+        collector = InfoCollector(
+            "counter", lambda name, *cfg: name, CollectionScope.ANNOTATION
+        )
+
+        # Run 1
+        info_collector.set_annotation_collectors([collector], (512,))
+        info_collector.clear_annotation_data()
+        info_collector.collect_for_annotation("add")
+        run1 = info_collector.get_collected_annotation_data()
+
+        # Run 2
+        info_collector.clear_annotation_data()
+        info_collector.collect_for_annotation("mul")
+        run2 = info_collector.get_collected_annotation_data()
+
+        assert len(run1) == 1 and run1[0]["annotation"] == "add"
+        assert len(run2) == 1 and run2[0]["annotation"] == "mul"
+
+    def test_off_thread_collection_sees_collectors(self) -> None:
+        """Process-global (not thread-local) state: a region entered from a
+        worker thread still sees collectors configured on the main thread.
+        With the old threading.local store this returned an empty dict."""
+        collector = InfoCollector(
+            "t", lambda name, *cfg: name, CollectionScope.ANNOTATION
+        )
+        info_collector.set_annotation_collectors([collector], (256,))
+        info_collector.clear_annotation_data()
+
+        captured: dict[str, object] = {}
+
+        def worker() -> None:
+            captured["collected"] = info_collector.collect_for_annotation("on_worker")
+
+        thread = threading.Thread(target=worker)
+        thread.start()
+        thread.join()
+
+        assert captured["collected"] == {"t": "on_worker"}
+        data = info_collector.get_collected_annotation_data()
+        assert any(d["annotation"] == "on_worker" for d in data)
+
+    def test_annotation_failure_is_isolated_and_warns(self) -> None:
+        info_collector.reset_collector_failure_warnings()
+
+        def boom(annotation_name, *config_args):  # type: ignore[no-untyped-def]
+            raise RuntimeError("collector blew up")
+
+        collector = InfoCollector("boom", boom, CollectionScope.ANNOTATION)
+        info_collector.set_annotation_collectors([collector], ())
+        info_collector.clear_annotation_data()
+
+        with pytest.warns(RuntimeWarning, match="boom"):
+            result = info_collector.collect_for_annotation("region")
+
+        assert result["boom"] is None
+
+
+class TestCollectorFailureWarning:
+    """warn_collector_failure surfaces failures regardless of output verbosity."""
+
+    def test_warns_once_per_collector(self) -> None:
+        info_collector.reset_collector_failure_warnings()
+        with pytest.warns(RuntimeWarning, match="flaky"):
+            info_collector.warn_collector_failure("flaky", "config", ValueError("x"))
+        # Second failure of the same collector should not warn again.
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # any warning would raise
+            info_collector.warn_collector_failure("flaky", "config", ValueError("y"))
+
+    def test_reset_warns_again_in_next_session(self) -> None:
+        info_collector.reset_collector_failure_warnings()
+        with pytest.warns(RuntimeWarning, match="flaky"):
+            info_collector.warn_collector_failure("flaky", "run", ValueError("x"))
+
+        info_collector.reset_collector_failure_warnings()
+        with pytest.warns(RuntimeWarning, match="flaky"):
+            info_collector.warn_collector_failure("flaky", "run", ValueError("y"))

--- a/tests/test_info_collector_integration.py
+++ b/tests/test_info_collector_integration.py
@@ -1,0 +1,757 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Integration tests for custom info collectors feature.
+
+These tests verify the complete data flow from collection to DataFrame output,
+including edge cases and bugs that have been discovered.
+"""
+
+from typing import Any
+
+from cuda.core import (  # pylint: disable=import-error
+    Device,
+    LaunchConfig,
+    Program,
+    ProgramOptions,
+    launch,
+)
+
+import nsight  # pylint: disable=import-error
+
+# Simple CUDA kernels for testing - no memory allocation to avoid extra internal kernels
+_kernel_code = r"""
+__global__ void dummy_kernel_add() {
+    // Simple no-op kernel for testing
+    int idx = threadIdx.x + blockIdx.x * blockDim.x;
+    (void)idx;  // Suppress unused variable warning
+}
+
+__global__ void dummy_kernel_mul() {
+    // Another simple no-op kernel for testing
+    int idx = threadIdx.x + blockIdx.x * blockDim.x;
+    (void)idx;  // Suppress unused variable warning
+}
+"""
+
+_compiled_module: Any = None
+
+
+def _get_compiled_module() -> Any:
+    """Lazily compile and cache the CUDA module."""
+    global _compiled_module  # pylint: disable=global-statement
+    if _compiled_module is None:
+        program_options = ProgramOptions(std="c++17")
+        prog = Program(_kernel_code, code_type="c++", options=program_options)
+        _compiled_module = prog.compile(
+            "cubin", name_expressions=("dummy_kernel_add", "dummy_kernel_mul")
+        )
+    return _compiled_module
+
+
+def _launch_kernel_add(n: int) -> None:
+    """Launch a simple add kernel (no memory allocation)."""
+    del n  # Not needed for dummy kernel
+    module = _get_compiled_module()
+    device = Device()
+    device.set_current()
+    stream = device.create_stream()
+
+    # Launch kernel with minimal grid/block
+    config = LaunchConfig(grid=1, block=256)
+    kernel = module.get_kernel("dummy_kernel_add")
+    launch(stream, config, kernel)
+
+    stream.sync()
+
+
+def _launch_kernel_mul(n: int) -> None:
+    """Launch a simple mul kernel (no memory allocation)."""
+    del n  # Not needed for dummy kernel
+    module = _get_compiled_module()
+    device = Device()
+    device.set_current()
+    stream = device.create_stream()
+
+    # Launch kernel with minimal grid/block
+    config = LaunchConfig(grid=1, block=256)
+    kernel = module.get_kernel("dummy_kernel_mul")
+    launch(stream, config, kernel)
+
+    stream.sync()
+
+
+# ============================================================================
+# Test 1: annotation_scope_reference_bug
+# ============================================================================
+
+_annotation_counter_ref_bug = {"count": 0}
+
+
+@nsight.experimental.collect(scope=nsight.CollectionScope.ANNOTATION)
+def _exec_counter_ref_bug(
+    annotation_name: str, *config_args: Any
+) -> int:  # pylint: disable=unused-argument
+    """Collector for reference bug test."""
+    _annotation_counter_ref_bug["count"] += 1
+    return _annotation_counter_ref_bug["count"]
+
+
+@nsight.analyze.kernel(
+    configs=[(512,), (1024,)],
+    runs=3,
+    verbosity=nsight.VerbosityLevel.SILENT,
+    info_collectors=[_exec_counter_ref_bug],
+)
+def benchmark_annotation_scope_reference_bug(n: int) -> None:
+    """Benchmark for testing annotation-scope reference bug."""
+    with nsight.annotate("add"):
+        _launch_kernel_add(n)
+
+    with nsight.annotate("mul"):
+        _launch_kernel_mul(n)
+
+
+def test_annotation_scope_reference_bug() -> None:
+    """
+    Test that annotation-scope collectors don't have reference bugs.
+
+    This is a regression test for a bug where get_collected_annotation_data()
+    was returning a reference to the thread-local list, causing all runs to
+    share the same list that was being cleared between runs.
+    """
+    results = benchmark_annotation_scope_reference_bug()
+
+    if results is None:
+        return  # No profiling data was returned.
+
+    df = results.to_dataframe()
+
+    # Check that we have the exec_counter columns
+    assert "_exec_counter_ref_bug_Min" in df.columns
+    assert "_exec_counter_ref_bug_Max" in df.columns
+    assert "_exec_counter_ref_bug_Avg" in df.columns
+
+    # For the first config (512), second annotation (mul):
+    # Runs 1, 2, 3: mul gets exec_counter values 2, 4, 6
+    # Min should be 2
+    first_mul = df[(df["n"] == 512) & (df["Annotation"] == "mul")]
+    assert len(first_mul) == 1
+    assert first_mul["_exec_counter_ref_bug_Min"].iloc[0] == 2
+    assert first_mul["_exec_counter_ref_bug_Max"].iloc[0] == 6
+
+    # For the first config (512), first annotation (add):
+    # Runs 1, 2, 3: add gets exec_counter values 1, 3, 5
+    # Min should be 1
+    first_add = df[(df["n"] == 512) & (df["Annotation"] == "add")]
+    assert len(first_add) == 1
+    assert first_add["_exec_counter_ref_bug_Min"].iloc[0] == 1
+    assert first_add["_exec_counter_ref_bug_Max"].iloc[0] == 5
+
+    # For the second config (1024), annotations should continue counting
+    # add: 7, 9, 11 (min=7, max=11)
+    # mul: 8, 10, 12 (min=8, max=12)
+    second_add = df[(df["n"] == 1024) & (df["Annotation"] == "add")]
+    assert second_add["_exec_counter_ref_bug_Min"].iloc[0] == 7
+    assert second_add["_exec_counter_ref_bug_Max"].iloc[0] == 11
+
+    second_mul = df[(df["n"] == 1024) & (df["Annotation"] == "mul")]
+    assert second_mul["_exec_counter_ref_bug_Min"].iloc[0] == 8
+    assert second_mul["_exec_counter_ref_bug_Max"].iloc[0] == 12
+
+
+# ============================================================================
+# Test 2: once_scope_collectors
+# ============================================================================
+
+_once_call_count = {"count": 0}
+
+
+@nsight.experimental.collect(scope=nsight.CollectionScope.ONCE)
+def _static_version() -> str:
+    """Once-scope collector for testing."""
+    _once_call_count["count"] += 1
+    return "v1.0.0"
+
+
+@nsight.analyze.kernel(
+    configs=[(512,), (1024,)],
+    runs=3,
+    verbosity=nsight.VerbosityLevel.SILENT,
+    info_collectors=[_static_version],
+)
+def benchmark_once_scope_collectors(n: int) -> None:
+    """Benchmark for testing once-scope collectors."""
+    with nsight.annotate("add"):
+        _launch_kernel_add(n)
+
+
+def test_once_scope_collectors() -> None:
+    """Test that once-scope collectors are called exactly once and constant across all rows."""
+    results = benchmark_once_scope_collectors()
+
+    if results is None:
+        return  # No profiling data was returned.
+
+    df = results.to_dataframe()
+
+    # Value should be constant across all rows.
+    assert "_static_version" in df.columns
+    assert all(df["_static_version"] == "v1.0.0")
+    assert df["_static_version"].nunique() == 1
+
+
+# ============================================================================
+# Test 3: config_scope_collectors
+# ============================================================================
+
+_collected_configs: list[int] = []
+
+
+@nsight.experimental.collect(scope=nsight.CollectionScope.CONFIG)
+def _track_config(n: int) -> int:
+    """Config-scope collector for testing."""
+    _collected_configs.append(n)
+    return n * 2
+
+
+@nsight.analyze.kernel(
+    configs=[(512,), (1024,)],
+    runs=2,
+    verbosity=nsight.VerbosityLevel.SILENT,
+    info_collectors=[_track_config],
+)
+def benchmark_config_scope_collectors(n: int) -> None:
+    """Benchmark for testing config-scope collectors."""
+    with nsight.annotate("add"):
+        _launch_kernel_add(n)
+
+
+def test_config_scope_collectors() -> None:
+    """Test that config collectors are called once per config with config args."""
+    _collected_configs.clear()
+    results = benchmark_config_scope_collectors()
+
+    if results is None:
+        return  # No profiling data was returned.
+
+    df = results.to_dataframe()
+
+    # Results should be aggregated.
+    assert "_track_config_Avg" in df.columns
+    assert "_track_config_Min" in df.columns
+    assert "_track_config_Max" in df.columns
+
+    # For n=512, value should be 1024 (512*2)
+    row_512 = df[df["n"] == 512]
+    assert row_512["_track_config_Avg"].iloc[0] == 1024
+
+    # For n=1024, value should be 2048 (1024*2)
+    row_1024 = df[df["n"] == 1024]
+    assert row_1024["_track_config_Avg"].iloc[0] == 2048
+    assert _collected_configs == [512, 1024]
+
+
+# ============================================================================
+# Test 3b: custom collectors combined with derive_metric (regression for H1)
+# ============================================================================
+
+
+@nsight.experimental.collect(scope=nsight.CollectionScope.ONCE)
+def _derive_static_version() -> str:
+    """Once-scope collector used alongside derive_metric."""
+    return "v9.9.9"
+
+
+@nsight.experimental.collect(scope=nsight.CollectionScope.CONFIG)
+def _derive_config_value(n: int) -> int:
+    """Config-scope numeric collector used alongside derive_metric."""
+    return n * 3
+
+
+def _derive_double(time_ns: float, n: int) -> tuple[float, str]:
+    """Derived metric: twice the kernel time (value, unit)."""
+    return (time_ns * 2.0, "ns2")
+
+
+@nsight.analyze.kernel(
+    configs=[(512,), (1024,)],
+    runs=2,
+    verbosity=nsight.VerbosityLevel.SILENT,
+    derive_metric=_derive_double,
+    info_collectors=[_derive_static_version, _derive_config_value],
+)
+def benchmark_collectors_with_derive_metric(n: int) -> None:
+    """Benchmark combining custom info collectors with a derive_metric."""
+    with nsight.annotate("add"):
+        _launch_kernel_add(n)
+
+
+def test_collectors_with_derive_metric() -> None:
+    """Regression (H1): custom-info columns must be populated on derived-metric
+    rows, not NaN/None. Previously transformed_df_data omitted custom_info_arrays
+    so every derived-metric row got NaN for collectors."""
+    results = benchmark_collectors_with_derive_metric()
+
+    if results is None:
+        return  # No profiling data was returned.
+
+    df = results.to_dataframe()
+
+    # The derived metric forms its own Metric rows (named after the function).
+    derived_rows = df[df["Metric"] == "_derive_double"]
+    assert not derived_rows.empty, "expected derived-metric rows"
+
+    # Once-scope string column: present and constant (NOT None/NaN) on derived rows.
+    assert "_derive_static_version" in df.columns
+    assert derived_rows["_derive_static_version"].notna().all()
+    assert (derived_rows["_derive_static_version"] == "v9.9.9").all()
+
+    # Config-scope numeric column: aggregated and non-NaN on derived rows.
+    assert "_derive_config_value_Avg" in df.columns
+    assert derived_rows["_derive_config_value_Avg"].notna().all()
+    # n=512 -> collector returns 512*3 = 1536.
+    derived_512 = derived_rows[derived_rows["n"] == 512]
+    assert derived_512["_derive_config_value_Avg"].iloc[0] == 1536
+
+
+# ============================================================================
+# Test 4: annotation_scope_collectors
+# ============================================================================
+
+_collected_annotation_data: list[tuple[str, int]] = []
+
+
+@nsight.experimental.collect(scope=nsight.CollectionScope.ANNOTATION)
+def _track_annotation(annotation_name: str, n: int) -> str:
+    """Annotation-scope collector for testing."""
+    _collected_annotation_data.append((annotation_name, n))
+    return f"{annotation_name}_{n}"
+
+
+@nsight.analyze.kernel(
+    configs=[(512,), (1024,)],
+    runs=2,
+    verbosity=nsight.VerbosityLevel.SILENT,
+    info_collectors=[_track_annotation],
+)
+def benchmark_annotation_scope_collectors(n: int) -> None:
+    """Benchmark for testing annotation-scope collectors."""
+    with nsight.annotate("add"):
+        _launch_kernel_add(n)
+
+    with nsight.annotate("mul"):
+        _launch_kernel_mul(n)
+
+
+def test_annotation_scope_collectors() -> None:
+    """Test that annotation-scope collectors are called per annotation and receive both annotation name and config."""
+    results = benchmark_annotation_scope_collectors()
+
+    if results is None:
+        return  # No profiling data was returned.
+
+    df = results.to_dataframe()
+
+    # Non-numeric annotation data should appear as-is (first value).
+    assert "_track_annotation" in df.columns
+
+    # Check specific values
+    add_512 = df[(df["n"] == 512) & (df["Annotation"] == "add")]
+    assert add_512["_track_annotation"].iloc[0] == "add_512"
+
+    mul_1024 = df[(df["n"] == 1024) & (df["Annotation"] == "mul")]
+    assert mul_1024["_track_annotation"].iloc[0] == "mul_1024"
+
+
+# ============================================================================
+# Test 5: mixed_scopes
+# ============================================================================
+
+
+@nsight.experimental.collect(scope=nsight.CollectionScope.ONCE)
+def _once_value() -> str:
+    """Once collector for mixed scopes test."""
+    return "once"
+
+
+@nsight.experimental.collect(scope=nsight.CollectionScope.CONFIG)
+def _config_value(n: int) -> int:
+    """Config collector for mixed scopes test."""
+    return n
+
+
+@nsight.experimental.collect(scope=nsight.CollectionScope.ANNOTATION)
+def _annotation_value(
+    annotation_name: str, n: int
+) -> int:  # pylint: disable=unused-argument
+    """Annotation collector for mixed scopes test."""
+    return len(annotation_name)
+
+
+@nsight.analyze.kernel(
+    configs=[(512,), (1024,)],
+    runs=2,
+    verbosity=nsight.VerbosityLevel.SILENT,
+    info_collectors=[_once_value, _config_value, _annotation_value],
+)
+def benchmark_mixed_scopes(n: int) -> None:
+    """Benchmark for testing all three scopes together."""
+    with nsight.annotate("add"):
+        _launch_kernel_add(n)
+
+
+def test_mixed_scopes() -> None:
+    """Test using collectors from all three scopes together."""
+    results = benchmark_mixed_scopes()
+
+    if results is None:
+        return  # No profiling data was returned.
+
+    df = results.to_dataframe()
+
+    # All three collectors should produce columns
+    assert "_once_value" in df.columns
+    assert "_config_value_Avg" in df.columns
+    assert "_annotation_value_Avg" in df.columns
+
+    # Once value should be constant
+    assert all(df["_once_value"] == "once")
+
+    # Config value should match n
+    assert df[df["n"] == 512]["_config_value_Avg"].iloc[0] == 512
+    assert df[df["n"] == 1024]["_config_value_Avg"].iloc[0] == 1024
+
+    # Annotation value should be len("add") = 3
+    assert all(df["_annotation_value_Avg"] == 3)
+
+
+# ============================================================================
+# Test 6: numeric_vs_non_numeric_aggregation
+# ============================================================================
+
+
+@nsight.experimental.collect(scope=nsight.CollectionScope.RUN)
+def _numeric_collector(n: int) -> int:  # pylint: disable=unused-argument
+    """Numeric collector for aggregation test."""
+    import random
+
+    return random.randint(100, 200)
+
+
+@nsight.experimental.collect(scope=nsight.CollectionScope.RUN)
+def _string_collector(n: int) -> str:
+    """String collector for aggregation test."""
+    return f"config_{n}"
+
+
+@nsight.analyze.kernel(
+    configs=[(512,)],
+    runs=5,
+    verbosity=nsight.VerbosityLevel.SILENT,
+    info_collectors=[_numeric_collector, _string_collector],
+)
+def benchmark_numeric_vs_non_numeric_aggregation(n: int) -> None:
+    """Benchmark for testing numeric vs non-numeric aggregation."""
+    with nsight.annotate("add"):
+        _launch_kernel_add(n)
+
+
+def test_numeric_vs_non_numeric_aggregation() -> None:
+    """Test that numeric collectors are aggregated while non-numeric ones take first value."""
+    results = benchmark_numeric_vs_non_numeric_aggregation()
+
+    if results is None:
+        return  # No profiling data was returned.
+
+    df = results.to_dataframe()
+
+    # Numeric collector should have aggregation columns
+    assert "_numeric_collector_Avg" in df.columns
+    assert "_numeric_collector_Std" in df.columns
+    assert "_numeric_collector_Min" in df.columns
+    assert "_numeric_collector_Max" in df.columns
+
+    # Non-numeric collector should appear as-is
+    assert "_string_collector" in df.columns
+    assert "_string_collector_Avg" not in df.columns
+
+    # Check that numeric values are within expected range
+    row = df.iloc[0]
+    assert 100 <= row["_numeric_collector_Min"] <= 200
+    assert 100 <= row["_numeric_collector_Max"] <= 200
+    assert 100 <= row["_numeric_collector_Avg"] <= 200
+
+    # String value should be the first collected value
+    assert row["_string_collector"] == "config_512"
+
+
+# ============================================================================
+# Test 7: collector_error_handling
+# ============================================================================
+
+_error_success_count = {"count": 0}
+
+
+@nsight.experimental.collect(scope=nsight.CollectionScope.RUN)
+def _failing_collector(n: int) -> int:
+    """Collector that fails for some configs."""
+    if n == 512:
+        raise ValueError("Simulated collection failure")
+    return n * 2
+
+
+@nsight.experimental.collect(scope=nsight.CollectionScope.RUN)
+def _success_collector(n: int) -> int:
+    """Collector that always succeeds."""
+    _error_success_count["count"] += 1
+    return n * 2
+
+
+@nsight.analyze.kernel(
+    configs=[(512,), (1024,)],
+    runs=1,
+    verbosity=nsight.VerbosityLevel.SILENT,
+    info_collectors=[_failing_collector, _success_collector],
+)
+def benchmark_collector_error_handling(n: int) -> None:
+    """Benchmark for testing collector error handling."""
+    with nsight.annotate("add"):
+        _launch_kernel_add(n)
+
+
+def test_collector_error_handling() -> None:
+    """Test that collector failures don't crash profiling."""
+    # Should not raise despite failing_collector error
+    results = benchmark_collector_error_handling()
+
+    if results is None:
+        return  # No profiling data was returned.
+
+    df = results.to_dataframe()
+
+    # Success collector returns n*2, aggregated per config.
+    assert "_success_collector_Avg" in df.columns
+    assert df[df["n"] == 512]["_success_collector_Avg"].iloc[0] == 1024
+    assert df[df["n"] == 1024]["_success_collector_Avg"].iloc[0] == 2048
+
+    # Failing collector raised for n=512 -> NaN there, but succeeded for
+    # n=1024 -> 2048. Profiling itself must not crash.
+    assert "_failing_collector_Avg" in df.columns
+    assert df[df["n"] == 512]["_failing_collector_Avg"].isna().iloc[0]
+    assert df[df["n"] == 1024]["_failing_collector_Avg"].iloc[0] == 2048
+
+
+# ============================================================================
+# Test 8: multiple_annotations_per_run
+# ============================================================================
+
+_annotation_order: list[str] = []
+
+
+@nsight.experimental.collect(scope=nsight.CollectionScope.ANNOTATION)
+def _track_order(
+    annotation_name: str, n: int
+) -> int:  # pylint: disable=unused-argument
+    """Annotation-scope collector for tracking order."""
+    _annotation_order.append(annotation_name)
+    return len(_annotation_order)
+
+
+@nsight.analyze.kernel(
+    configs=[(512,)],
+    runs=2,
+    verbosity=nsight.VerbosityLevel.SILENT,
+    info_collectors=[_track_order],
+)
+def benchmark_multiple_annotations_per_run(n: int) -> None:
+    """Benchmark for testing multiple annotations."""
+    with nsight.annotate("first"):
+        _launch_kernel_add(n)
+
+    with nsight.annotate("second"):
+        _launch_kernel_mul(n)
+
+    with nsight.annotate("third"):
+        _launch_kernel_add(n)
+
+
+def test_multiple_annotations_per_run() -> None:
+    """Test that annotation-scope collectors work correctly with multiple annotations."""
+    results = benchmark_multiple_annotations_per_run()
+
+    if results is None:
+        return  # No profiling data was returned.
+
+    df = results.to_dataframe()
+
+    # Should have 3 rows (one per annotation).
+    assert len(df) == 3
+
+    # Each annotation should have different min/max values showing execution order
+    first = df[df["Annotation"] == "first"]
+    second = df[df["Annotation"] == "second"]
+    third = df[df["Annotation"] == "third"]
+
+    # first runs at positions 1 and 4
+    assert first["_track_order_Min"].iloc[0] == 1
+    assert first["_track_order_Max"].iloc[0] == 4
+
+    # second runs at positions 2 and 5
+    assert second["_track_order_Min"].iloc[0] == 2
+    assert second["_track_order_Max"].iloc[0] == 5
+
+    # third runs at positions 3 and 6
+    assert third["_track_order_Min"].iloc[0] == 3
+    assert third["_track_order_Max"].iloc[0] == 6
+
+
+# ============================================================================
+# Test 9: decorator_based_api
+# ============================================================================
+
+
+@nsight.experimental.collect(scope=nsight.CollectionScope.ONCE)
+def _my_once_collector() -> str:
+    """Once collector for decorator API test."""
+    return "once_value"
+
+
+@nsight.experimental.collect(scope=nsight.CollectionScope.CONFIG)
+def _my_config_collector(n: int) -> int:
+    """Config collector for decorator API test."""
+    return n
+
+
+@nsight.experimental.collect(scope=nsight.CollectionScope.RUN)
+def _my_run_collector(n: int) -> int:
+    """Run collector for decorator API test."""
+    return n
+
+
+@nsight.experimental.collect(scope=nsight.CollectionScope.ANNOTATION)
+def _my_annotation_collector(
+    annotation_name: str, n: int
+) -> str:  # pylint: disable=unused-argument
+    """Annotation collector for decorator API test."""
+    return annotation_name
+
+
+@nsight.analyze.kernel(
+    configs=[(512,)],
+    runs=1,
+    verbosity=nsight.VerbosityLevel.SILENT,
+    info_collectors=[
+        _my_once_collector,
+        _my_config_collector,
+        _my_run_collector,
+        _my_annotation_collector,
+    ],
+)
+def benchmark_decorator_based_api(n: int) -> None:
+    """Benchmark for testing the decorator-based API."""
+    with nsight.annotate("add"):
+        _launch_kernel_add(n)
+
+
+def test_decorator_based_api() -> None:
+    """Test the decorator-based API for defining collectors."""
+    results = benchmark_decorator_based_api()
+
+    if results is None:
+        return  # No profiling data was returned.
+
+    df = results.to_dataframe()
+
+    # Column names should match function names
+    assert "_my_once_collector" in df.columns
+    assert "_my_config_collector_Avg" in df.columns
+    assert "_my_run_collector_Avg" in df.columns
+    assert "_my_annotation_collector" in df.columns
+
+
+# ============================================================================
+# Test 10: empty_collectors_list
+# ============================================================================
+
+
+@nsight.analyze.kernel(
+    configs=[(512,)],
+    runs=1,
+    verbosity=nsight.VerbosityLevel.SILENT,
+    info_collectors=[],
+)
+def benchmark_empty_collectors(n: int) -> None:
+    """Benchmark with empty collectors list."""
+    with nsight.annotate("add"):
+        _launch_kernel_add(n)
+
+
+@nsight.analyze.kernel(configs=[(512,)], runs=1, verbosity=nsight.VerbosityLevel.SILENT)
+def benchmark_none_collectors(n: int) -> None:
+    """Benchmark with no collectors specified."""
+    with nsight.annotate("add"):
+        _launch_kernel_add(n)
+
+
+def test_empty_collectors_list() -> None:
+    """Test that profiling works with empty or no collectors."""
+    # Both should work without errors
+    results1 = benchmark_empty_collectors()
+    results2 = benchmark_none_collectors()
+
+    # Some collector implementations may return no profiling data.
+    if results1 is not None:
+        assert results1 is not None
+    if results2 is not None:
+        assert results2 is not None
+
+
+# ============================================================================
+# Test 11: column_ordering
+# ============================================================================
+
+
+@nsight.experimental.collect(scope=nsight.CollectionScope.ONCE)
+def _z_collector() -> str:
+    """Once collector with name starting with 'z' for ordering test."""
+    return "z_value"
+
+
+@nsight.experimental.collect(scope=nsight.CollectionScope.CONFIG)
+def _a_collector(n: int) -> int:
+    """Config collector with name starting with 'a' for ordering test."""
+    return n * 2
+
+
+@nsight.analyze.kernel(
+    configs=[(512,)],
+    runs=1,
+    verbosity=nsight.VerbosityLevel.SILENT,
+    info_collectors=[_z_collector, _a_collector],
+)
+def benchmark_column_ordering(n: int) -> None:
+    """Benchmark for testing column ordering."""
+    with nsight.annotate("add"):
+        _launch_kernel_add(n)
+
+
+def test_column_ordering() -> None:
+    """Test that custom info columns are present in the DataFrame."""
+    results = benchmark_column_ordering()
+
+    if results is None:
+        return  # No profiling data was returned.
+
+    df = results.to_dataframe()
+
+    # Verify all expected columns exist
+    assert "_z_collector" in df.columns
+    assert "_a_collector_Avg" in df.columns
+    assert "n" in df.columns
+
+    # Verify the values are correct
+    assert df["_z_collector"].iloc[0] == "z_value"
+    assert df["_a_collector_Avg"].iloc[0] == 1024  # 512 * 2
+    assert df["n"].iloc[0] == 512


### PR DESCRIPTION
## Summary

Adds experimental custom information collectors to Nsight Python profiling results. Collectors can add static, configuration-specific, run-specific, or annotation-specific columns to the resulting DataFrame.

## API

The separate scope-specific decorators have been replaced by one provisional API:

```python
@nsight.experimental.collect(scope=nsight.CollectionScope.ONCE)
def driver_version():
    from cuda.core import system

    return ".".join(
        str(part) for part in system.get_user_mode_driver_version()
    )


@nsight.experimental.collect(scope=nsight.CollectionScope.CONFIG)
def matrix_elements(n, dtype):
    return n * n


@nsight.experimental.collect(scope=nsight.CollectionScope.RUN)
def gpu_temperature(n, dtype):
    return read_gpu_temperature()


@nsight.experimental.collect(scope=nsight.CollectionScope.ANNOTATION)
def annotation_timestamp(annotation_name, *config_args):
    return time.time()


@nsight.analyze.kernel(
    info_collectors=[
        driver_version,
        matrix_elements,
        gpu_temperature,
        annotation_timestamp,
    ]
)
def benchmark(n, dtype):
    ...
```

The decorator also accepts string scopes and direct-call syntax. `InfoCollector` objects and `(name, callback, scope)` tuples remain supported.

## Collection scopes

| Scope | Invocation |
| --- | --- |
| `ONCE` | Once at the start of the profiling session |
| `CONFIG` | Once for each configuration |
| `RUN` | Once for every repeated run of each configuration |
| `ANNOTATION` | At the start of every annotated region |

Numeric values collected at config, run, or annotation scope are aggregated across raw rows. Non-numeric values retain the first value. Once-scope values remain constant across the result.

## Validation

- 28 focused collector and transformation tests pass.
- Introduced a new example (`13_custom_info_collectors.py`) and updated documentation illustrating usage.
- Strict mypy passes for all touched source files.
- Black, isort, compilation, and diff checks pass.